### PR TITLE
Adding the InfluxDB Single and Multi-user Secret Rotation Lambdas.

### DIFF
--- a/SecretsManagerInfluxDBMultiUserRotation/README.md
+++ b/SecretsManagerInfluxDBMultiUserRotation/README.md
@@ -1,11 +1,11 @@
 # Amazon InfluxDB Multi User Rotator
 
 ## Getting Started
-The InfluxDB Multi-User Rotator is used to rotate a user's authorization token or credentials with the use of the AWS Secrets Manager. The Multi-user rotator operates by using an operator authenticated session to rotate a users token or credentials with a new permission identical token or credential. The rotating token or credentials can have any permissions, and the Secrets Manager token must be an operator token. See [InfluxDB Documentation](https://docs.influxdata.com/influxdb/v2/admin/tokens) for how to create and manage tokens. The benefit of using an operator to rotate a users token is that the rotating user does not require the associated read and write permissions to complete the token rotation.
+The InfluxDB Multi-User Rotator is used to rotate a user's authorization token or credentials with the use of the AWS Secrets Manager. The Multi-user rotator operates by using an operator authenticated session to rotate a user's token or credentials with a new permission identical token or credential. The rotating token or credentials can have any permissions, and the Secrets Manager token must be an operator token. See [InfluxDB Documentation](https://docs.influxdata.com/influxdb/v2/admin/tokens) for how to create and manage tokens. The benefit of using an operator token to rotate a user's token is that the rotating user does not require the associated read and write permissions to complete the token rotation.
 
 ### InfluxDB Multi-user Token Rotation State Diagram
 
-The InfluxDB Multi-user Token Rotation State Diagram illustrates how an admin users token authenticates the rotation of another users token with each successful step provided by the `Secrets Manager`.
+The InfluxDB Multi-user Token Rotation State Diagram illustrates how an admin user's token authenticates the rotation of another user's token with each successful step provided by the `Secrets Manager`.
 
 ```mermaid
 stateDiagram-v2
@@ -137,7 +137,7 @@ Username and Password Credentials (for rotating user password)
 
 ## Deploy Lambda
 1. Execute script with the following command (Requires pip3 installed)
-- If you are using MacOS or Linux, execute the following commands
+- If you are using macOS or Linux, execute the following commands
   - `./build_deployment.sh`_(to build deployable lambda function package from the source code)_
   - Execute the following command to add execution permissions to your deployment package
   - `sudo chmod +x influxdb-token-rotation-lambda.zip`

--- a/SecretsManagerInfluxDBMultiUserRotation/README.md
+++ b/SecretsManagerInfluxDBMultiUserRotation/README.md
@@ -1,0 +1,357 @@
+# Amazon InfluxDB Multi User Rotator
+
+## Getting Started
+The InfluxDB Multi-User Rotator is used to rotate a user's authorization token or credentials with the use of the AWS Secrets Manager. The Multi-user rotator operates by using an operator authenticated session to rotate a users token or credentials with a new permission identical token or credential. The rotating token or credentials can have any permissions, and the Secrets Manager token must be an operator token. See [InfluxDB Documentation](https://docs.influxdata.com/influxdb/v2/admin/tokens) for how to create and manage tokens. The benefit of using an operator to rotate a users token is that the rotating user does not require the associated read and write permissions to complete the token rotation.
+
+### InfluxDB Multi-user Token Rotation State Diagram
+
+The InfluxDB Multi-user Token Rotation State Diagram illustrates how an admin users token authenticates the rotation of another users token with each successful step provided by the `Secrets Manager`.
+
+```mermaid
+stateDiagram-v2
+direction LR
+    createSecret --> testSecret: Success
+    testSecret --> finishSecret: Success
+
+    state "Step: createSecret" as createSecret
+    state createSecret {
+        Secretsmanager1: Secrets Manager
+        state1admintoken: Admin token
+        state1oldtoken: old token
+        state1newtoken: new token
+
+        Secretsmanager1 --> AdminUser1 : step - createSecret
+        AdminUser1 --> User1 : Creates new user token
+
+        state "AdminUser" as AdminUser1 {
+            state1admintoken
+        }
+        state "User" as User1 {
+            state1oldtoken
+            state1newtoken
+        }
+    }
+
+    state "Step: testSecret" as testSecret
+    state testSecret {
+        Secretsmanager2: Secrets Manager
+        state2admintoken: Admin token
+        state2oldtoken: old token
+        state2newtoken: new token
+
+        Secretsmanager2 --> AdminUser2 : step - testSecret
+        AdminUser2 --> User2 : Validates new vs old token permissions
+
+        state "AdminUser" as AdminUser2 {
+            state2admintoken
+        }
+        state "User" as User2 {
+            state2oldtoken
+            state2newtoken
+        }
+    }
+
+    state "Step: finishSecret" as finishSecret
+    state finishSecret {
+        Secretsmanager3: Secrets Manager
+        state3admintoken: Admin token
+        state3newtoken: new token
+
+        Secretsmanager3 --> AdminUser3 : step - finishSecret
+        AdminUser3 --> User3 : Deletes old token
+
+        state "AdminUser" as AdminUser3 {
+            state3admintoken
+        }
+        state "User" as User3 {
+            state3newtoken
+        }
+    }
+
+    classDef green fill:#32cd32
+    classDef orange fill:#f96
+    classDef yellow fill:#eeff1b
+    class state1newtoken orange
+    class state2newtoken, state2oldtoken yellow
+    class state3newtoken green
+```
+
+## Permissions
+The `InfluxDB Multi-user Rotation Lambda` rotates existing tokens with the same permissions that are defined for the token in the DB instance. This is to avoid any scenarios where a tokens permissions can escalate during the rotation. Changing the type of the authentication token will not change the permissions for that token. If you wish to alter the permissions of a token with this lambda function, a new non-operator token must be created and can only be created when the environment variable `AUTHENTICATION_CREATION_ENABLED` is set to `true` in the lambda function. The token type and permission values defined in a secret, are only applied to a token when a new secret is defined without a token value.
+
+## Create Secret
+1. Open the AWS console
+- Navigate to `Secrets Manager`
+- Click `Store a new secret`
+- Select `Other type of secret`
+- Click on `Plaintext` under `Key/value pairs`
+- Fill in one of the following options in the text box:
+
+Token Credentials (for token rotation)
+```
+{
+    "engine": "timestream-influxdb",            // mandatory engine name
+    "org": "string",                            // mandatory organization to associate token with
+    "operatorTokenArn": "string",               // mandatory arn for operator token
+    "type": "string",                           // "allAccess" or "operator" or "custom" # 'operator' mutually exclusive with all below
+    "dbIdentifier": "string",                   // mandatory DB instance identifier
+    "token": "string",                          // optional, actual secret string. If added the lambda will delete this value and rotate to new value. If token type is operator the field is mandatory. If ommitted a new token will be created when authentication creation is enabled.
+    "writeBucket": ["string", "string", ...],   // optional list of bucketIDs, must be input with the plaintext panel of the secrets manager.
+    "readBucket": ["string", "string", ...],    // optional list of bucketIDs, must be input with the plaintext panel of the secrets manager.
+    "permissions": ["string", "string", ...]    // optional list, i.e. ["write-tasks", "read-tasks"], must be input with the plaintext panel of the secrets manager.
+}
+```
+
+Username and Password Credentials (for rotating user password)
+```
+{
+    "engine": "timestream-influxdb",            // mandatory engine name
+    "username": "string",                       // mandatory username for rotating user
+    "dbIdentifier": "string",                   // mandatory DB instance identifier
+    "operatorTokenArn": "string",               // mandatory arn for operator token
+    "org":  "string",                           // optional, scope for user
+    "password": "string"                        // optional, user will be created if empty and authentication creation is enabled
+}
+```
+- Click `Next`
+- Enter a name for the secret of your choosing
+- Click `Next`
+- Click `Next` again as we will configure the rotation after we deploy the lambda
+- Click `Store`
+
+> **NOTE**: If the token type is of type `custom`, you must enter and make any edits to the secret value in the `plaintext` panel of the `Secret Manager` console. See the following example of a token secret of type `custom`:
+```
+{
+    "engine": "timestream-influxdb",
+    "type": "custom",
+    "operatorTokenArn": "arn:aws:secretsmanager:<region>:<account_id>:secret>:...",
+    "dbIdentifier": "abcdefg",
+    "token": "1234567890abcdefghijklmnop==",
+    "org": "org",
+    "writeBucket": ["bucket1","bucket2"],
+    "readBuckets": ["bucket1","bucket2"],
+    "permissions": ["write-buckets","read-buckets"]
+}
+```
+
+
+## Deploy Lambda
+1. Execute script with the following command (Requires pip3 installed)
+- If you are using MacOS or Linux, execute the following commands
+  - `./build_deployment.sh`_(to build deployable lambda function package from the source code)_
+  - Execute the following command to add execution permissions to your deployment package
+  - `sudo chmod +x influxdb-token-rotation-lambda.zip`
+- If you are using Windows, execute the following command
+  - `./build_deployment.ps1`_(to build deployable lambda function package from the source code)_
+
+2. Open the AWS console
+- Navigate to `Lambda`
+- Click `Create function`
+- Enter a function name of your choosing
+- Select `Python 3.12` for the Runtime
+- Click `Create function`
+
+3. Upload the deployment package
+- Click on `Upload from` and select `.zip` file
+- Click `Upload` and select the `influxdb-token-rotation-lambda.zip` deployment package
+- Click `Save`
+
+4. Configure environment variables for the lambda function
+- Click on `Configuration`
+- Click on `Environment Variables` and click on `Edit`
+- Click on `Add environment variable`
+- Enter `SECRETS_MANAGER_ENDPOINT` for the key value
+- Enter `https://secretsmanager.<region>.amazonaws.com` and replace `<region>` appropriately (Must be same as `Secrets Manager`)
+- Click `Save`
+
+5. If you wish to enable authentication creation with secrets, add the following environment variable
+- Click on `Add environment variable`
+- Enter `AUTHENTICATION_CREATION_ENABLED` for the key and `true` for the value
+- Click `Save`
+
+6. Configure lambda role
+- Click on `Permissions`
+- Under `Execution role` click on the link to the lambda role
+- Under `Permissions policies` click `Add permissions` and `Create inline policy`
+- Click on `JSON` and replace the json in the text editor with the following:
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:PutSecretValue",
+                "secretsmanager:UpdateSecretVersionStage"
+            ],
+            "Resource": "<user_secret_arn>"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetSecretValue"
+            ],
+            "Resource": "<operator_secret_arn>"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetRandomPassword"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "timestream-influxdb:GetDbInstance"
+            ],
+            "Resource": "arn:aws:timestream-influxdb:<region>:<account_id>:db-instance/<db_instance_id>",
+            "Effect": "Allow"
+        }
+    ]
+}
+```
+- Replace `<region>`, `<account_id>`, `<db_instance_id>`, `<user_secret_arn>`, and `<operator_secret_arn>` appropriately
+- Click `Next`
+- Enter a `Policy name` of your choosing and click `Create policy`
+
+7. Configure invoke lambda permissions for the lambda function
+- Navigate back to the lambda function `Permissions` section
+- Under `Resource-based policy statements` click `Add permissions`
+- Click on `AWS service`
+- Select `Secrets Manager` under `Service`
+- Enter a `Statement ID` of your choosing
+- Select `Lambda:InvokeFunction` under `Action`
+- Click `Save`
+
+8. Configure lambda function timeout
+- Navigate to the lambda function `General configuration` section
+- Under `General configuration` click `Edit`
+- Set the `Timeout` value to 1 minute
+- Click `Save`
+
+## Configure Token Rotation
+1. Open the AWS console
+- Navigate to `Secrets Manager`
+- Select the secret that was previously created
+- Click `Rotation` and then `Edit rotation`
+- Click on `Automatic rotation`
+- Fill in the rotation schedule of your choosing
+- Under `Rotation function` select the lambda function we previously deployed
+- Ensure the checkbox to rotate immediately when stored is selected
+- Click `Save`
+
+## Verify
+1. In the secret that we created navigate to the `Overview` section
+- Click `Retrieve secret value`
+- If everything went correctly you should see a new token value under `influxdb-user-token`
+- If the value for `influxdb-user-token` has not changed, see section [Viewing CloudWatch Logs](#viewing-cloudwatch-logs) for troubleshooting
+
+## Viewing CloudWatch Logs
+1. Navigate to `Lambda`
+- Click on the function created for rotating your `InfluxDB` token
+- Click on `Monitor`
+- Click on `View CloudWatch logs`
+- Click on the latest log stream under `Log streams`
+- Look for any `Error` or `Info` logs that can help determine the reason for failure to rotate the token
+
+## Adding Rotation Lambda to same VPC as Timestream for InfluxDB
+**Note** - This is not required, but is a configuration option for users requiring the `InfluxDB Rotation Lambda` to run on the same `VPC` as their `Timestream for InfluxDB` Instance.
+
+1. Adding the `InfuxDB Rotation Lambda` to a `VPC` will require the addition of a `NAT Gateway`
+- We will create three `Subnets`(One for each `availability zone`) pointing to one `Route table` that routes to the `NAT Gateway`
+- Your `Timestream for InfluxDB` instance should already have a `VPC` with a `Subnet` and `Route Table` to an `Internet Gateway`
+- If your `VPC` already has a `NAT Gateway` with appropriate `Subnet` and `Route Tables`, you can skip to step `#5`
+
+<br>
+
+2. Create a `NAT Gateway`
+- If you already have a `NAT Gateway`, skip to step `#3`
+- Click on `NAT Gateway` in the left side bar
+- Click on `Create NAT Gateway`
+- Fill in the `Name` of your choosing, and select the `Subnet` to be `lambda-subnet-point-to-ig` that you created earlier
+- Select `Public` for `Connectivity type` and click `Allocate elastic IP`
+- Click `Create NAT Gateway`
+
+<br>
+
+3. Create a `Route Table` for the `NAT Gateway`
+- If you already have a route to a `NAT Gateway`, skip to step `#4`
+- Click on `Route tables` in the left side bar
+- Click `Create route table`
+- Fill in the `Name` portion and select the `VPC`
+- Click `Create route`
+- Click on `Edit routes` and `Add route`
+- Select `0.0.0.0/0` for the `Destination`
+- Select `NAT Gateway` for `Target` and fill in the `NAT Gateway` we created earlier
+- Click `Save Changes`
+
+<br>
+
+4. Adding `Subnets` for the `Nat Gateway`
+- If you already have three `Subnets` for the `NAT Gateway`, skip to step `#5`
+- Navigate to `VPC` and select `Subnets` in the left side bar
+- Click `Create subnet` and select the `VPC ID` of your `VPC`
+- We will create three subnets pointing to the `NAT Gateway`, each incrementing the second to last byte of the `IPv4 subnet CIDR block` address by 16, ensure these addresses don't overlap with already existing `Subnets`
+- Each `Subnet` will be in their own `availability zone`
+- See the following table for reference, and set the IP's dependent on your `VPC IPv4 CIDR`
+
+<br>
+
+| VPC | CIDR | Name |
+| --- | ---- | --- |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.0.0/20  | lambda-subnet-point-to-nat-1 |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.16.0/20 | lambda-subnet-point-to-nat-2 |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.32.0/20 | lambda-subnet-point-to-nat-3 |
+
+- Click on the `Create Subnet` for each `Subnet` in the table
+
+<br>
+
+5. Setup `InfluxDB Rotation Lambda`
+- Navigate to `Lambda` and select the `InfluxDB Rotation Lambda`
+- Click on `Configuration` and select `VPC` in the left side bar
+- Click on `Edit` under `VPC`
+- Select the `VPC` of the `Timestream for InfluxDB` instance
+- Select the three subnets pointing to the `NAT Gateway`
+- Select the default security group
+- Click `Save`
+
+<br>
+
+6. Your `InfluxDB Rotation Lambda` should now have internet access
+- Below I have listed all required components to the VPC for referece
+- Your configuration may look different, but if you have a `Route` from your private `Subnets` to a `NAT Gateway` linking through to the `Internet Gateway`, the lambda function should have internet access
+
+<br>
+
+| VPC | CIDR | Name | Route Table | Network Connection |
+| --- | ---- | --- | --- | --- |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.0.0/20  | lambda-subnet-point-to-nat-1 | route-to-nat-gw | NAT Gateway |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.16.0/20 | lambda-subnet-point-to-nat-2 | route-to-nat-gw | NAT Gateway |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.32.0/20 | lambda-subnet-point-to-nat-3 | route-to-nat-gw | NAT Gateway |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.48.0/20 | lambda-subnet-point-to-ig    | route-to-ig     | Internet Gateway |
+
+## VPC Network Configuration Diagram
+
+![image](UML/InfluxDB-Rotation-Lambda-Network-Configuration.png)
+
+## Testing
+
+### Integration Tests
+
+To run the integration tests using the default region defined in the `AWS_DEFAULT_REGION` environment variable, execute the following while your shell is in the `integration` directory:
+
+```shell
+python3 integration_test.py
+```
+
+If the `AWS_DEFAULT_REGION` environment variable is not set or you wish to use a different region, the `--region <region name>` argument will let you set the region to use.
+
+The integration tests will use `boto3` to create a new Timestream for InfluxDB instance (size medium with 20GB of of storage), a VPC required for the Timestream for InfluxDB instance, a lambda function containing `lambda_function.py` and dependencies, an admin secret, and a user secret, which will be rotated. The integration tests tags these resources; if resources with these tags already exist, then these existing resources will be used.
+
+In addition to the above-mentioned `--region` argument, the integration tests support inividual test arguments, such as running an individual test with `python3 integration_test.py SecretsTestCase.test_operator_token_rotation`, and the option to delete all tagged integration test resources after testing by using `--cleanup`.
+
+> **NOTE**: The secrets created by the IT test should not be deleted via the AWS console, as deletion via the AWS console puts secrets into a pending deletion stage where secrets will still be identified by the integration tests. If you wish to delete the integration test secrets manually, without using `--cleanup`, delete them using the AWS CLI with `aws secretsmanager delete-secret --secret-id <secret ID> --force-delete-without-recovery`.

--- a/SecretsManagerInfluxDBMultiUserRotation/README.md
+++ b/SecretsManagerInfluxDBMultiUserRotation/README.md
@@ -322,7 +322,7 @@ Username and Password Credentials (for rotating user password)
 <br>
 
 6. Your `InfluxDB Rotation Lambda` should now have internet access
-- Below I have listed all required components to the VPC for referece
+- Below I have listed all required components to the VPC for reference
 - Your configuration may look different, but if you have a `Route` from your private `Subnets` to a `NAT Gateway` linking through to the `Internet Gateway`, the lambda function should have internet access
 
 <br>

--- a/SecretsManagerInfluxDBMultiUserRotation/build_deployment.ps1
+++ b/SecretsManagerInfluxDBMultiUserRotation/build_deployment.ps1
@@ -1,0 +1,96 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Ensure that binary is installed in the local environment
+Function check_command_installed ($Command) {
+    if (-Not (Get-Command $Command -errorAction SilentlyContinue))
+    {
+        Write-Output "$Command could not be found, please install it and re-run this script."
+        exit 1
+    }
+}
+
+# Get user input to verify that the binary installed has the expected path value
+Function binary_input_verification ($BinaryName, $BinaryPath) {
+    Write-Host "This script uses $BinaryName with the following absolute path:"
+    Write-Host $BinaryPath 
+    Write-Host "If this is the expected path for $BinaryName then type 'y' to continue: "
+    $continue_confirmation = Read-Host -Prompt "y/n"
+
+    if (-Not ([string]$continue_confirmation -eq "y"))
+    {
+        Write-Host "Script Aborted"
+        exit 1
+    }
+}
+
+# Output the help dialogue for how to use this script
+Function show_help_dialogue()
+{
+    Write-Output "
+        Usage: build_deployment.ps1 [-F Format] [-L Linter] [-D Deploy]
+
+        -F Format       Run the ruff formatter.
+        -L Linter       Run the ruff linter.
+        -D Deploy       Build and package the deployment.
+
+        For Example: ./build_deployment.ps1 -D
+    "
+}
+
+if ($($args.Count) -eq 0)
+{
+    show_help_dialogue
+    exit 1
+}
+
+ForEach ($arg in $args) {
+    switch -Exact ($arg)
+    {
+        {($_ -eq "-F") -or ($_ -eq "-L")}
+        {
+            check_command_installed "ruff";
+            $ruff_installed_path=$(Get-Command "ruff").Source
+            binary_input_verification "ruff" $ruff_installed_path
+            if ($_ -eq "-F")
+            {
+                Write-Output "Running Formatter";
+                ruff format
+            }
+            else
+            {
+                Write-Output "Running Linter";
+                ruff check
+            }
+            exit 1            
+        }
+        {($_ -eq "-D")} 
+        {
+            Write-Output "Building Deployment";
+            break
+        }
+        Default 
+        {
+            Write-Output "Invalid option: $arg";
+            exit 1
+        }
+    }
+}
+
+# Ensure pip3 is installed and verify the binary location
+check_command_installed "pip3"
+$pip3_installed_path=$(Get-Command "pip3").Source
+binary_input_verification "pip3" $pip3_installed_path
+
+# Make a temporary directory and populate with dependencies
+mkdir tmp-influxdb-deployment-lambda
+cd tmp-influxdb-deployment-lambda
+pip3 install -r ..\requirements.txt -t . --no-user
+
+# Copy the lambda function code and create a zip of lambda with dependencies
+copy ..\lambda_function.py .\
+Compress-Archive -Path * -DestinationPath ..\influxdb-token-rotation-lambda.zip -CompressionLevel Optimal -Force
+
+# Cleanup
+cd ..\
+Remove-Item -Path .\tmp-influxdb-deployment-lambda -Force -Recurse

--- a/SecretsManagerInfluxDBMultiUserRotation/build_deployment.sh
+++ b/SecretsManagerInfluxDBMultiUserRotation/build_deployment.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Ensure that binary is installed in the local environment
+check_command_installed () {
+    bin_path=$(command -v $1)
+    if [ "${bin_path}" == "" ];
+    then
+        echo "$1 could not be found, please install it and re-run this script." >&2
+        exit 1
+    fi
+    echo "$bin_path"
+}
+
+# Output the help dialogue for how to use this script
+show_help_dialogue()
+{
+echo "
+        Usage: build_deployment.sh [-F Format] [-L Linter] [-D Deploy]
+
+        -F Format       Run the ruff formatter.
+        -L Linter       Run the ruff linter.
+        -D Deploy       Build and package the deployment.
+
+        For Example: ./build_deployment.sh -D
+"
+}
+
+if [ $# -eq 0 ]
+then
+  show_help_dialogue
+  exit 1
+fi
+
+while getopts "FLD" flag; do
+  case $flag in
+    F|L)
+      ruff_bin_path="$(check_command_installed "ruff")"
+      [ -z "${ruff_bin_path}" ] && exit 1
+      echo "This script uses the ruff binary with the following absolute path:"
+      echo "$ruff_bin_path"
+      read -p "If this is the expected path for this binary type 'y' to continue: " -r
+      if [ "$flag" == "F" ]
+      then
+        echo "Running Formatter"
+        format_result=$(ruff format)
+        echo "$format_result"
+      else
+        echo "Running Linter"
+        lint_result=$(ruff check)
+        echo "$lint_result"
+      fi
+      exit 1
+      ;;
+    D)
+      echo "Building Deployment"
+      ;;
+    \?)
+      echo "Invalid option: -$flag"
+      exit 1
+      ;;
+  esac
+done
+
+# Ensure pip3 and zip is installed
+pip3_bin_path="$(check_command_installed "pip3")"
+[ -z "${pip3_bin_path}" ] && exit 1
+zip_bin_path="$(check_command_installed "zip")"
+[ -z "${zip_bin_path}" ] && exit 1
+
+# Verify the installed binary locations are in the expected locations
+echo "This script uses pip3 and zip binaries with the following absolute paths:"
+echo "$pip3_bin_path"
+echo "$zip_bin_path"
+read -p "If these are the expected paths for these binaries type 'y' to continue: " -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo "Script Aborted"
+    exit 1
+fi
+
+# Make a temporary directory and populate with dependencies
+mkdir tmp-influxdb-deployment-lambda
+cd tmp-influxdb-deployment-lambda
+pip3 install -r ../requirements.txt -t .
+
+# Copy the lambda function code and create a zip of lambda with dependencies
+/bin/cp ../lambda_function.py ./
+zip -r ../influxdb-token-rotation-lambda.zip .
+
+# # Cleanup
+cd ../
+rm -rf tmp-influxdb-deployment-lambda

--- a/SecretsManagerInfluxDBMultiUserRotation/integration/aws_integration_test_client.py
+++ b/SecretsManagerInfluxDBMultiUserRotation/integration/aws_integration_test_client.py
@@ -15,7 +15,6 @@ from integration_test_utils import random_string, logger
 
 class AWSIntegrationTestClient:
     ROTATION_TIMEOUT_SECONDS = 60
-    VERSION_ID_LENGTH = 32  # Minimum accepted version ID length
     LAMBDA_FUNCTION_TAG_KEY = "tmp-influxdb-integration-test-lambda-function"
     LAMBDA_FUNCTION_TAG_VALUE = "multi-user-rotation-integration-lambda"
     LAMBDA_FUNCTION_RUNTIME = "python3.12"

--- a/SecretsManagerInfluxDBMultiUserRotation/integration/aws_integration_test_client.py
+++ b/SecretsManagerInfluxDBMultiUserRotation/integration/aws_integration_test_client.py
@@ -1,0 +1,598 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import json
+from pathlib import Path
+from sys import platform
+import time
+import subprocess
+import uuid
+import os
+
+import boto3
+from integration_test_utils import random_string, logger
+
+
+class AWSIntegrationTestClient:
+    ROTATION_TIMEOUT_SECONDS = 60
+    VERSION_ID_LENGTH = 32  # Minimum accepted version ID length
+    LAMBDA_FUNCTION_TAG_KEY = "tmp-influxdb-integration-test-lambda-function"
+    LAMBDA_FUNCTION_TAG_VALUE = "multi-user-rotation-integration-lambda"
+    LAMBDA_FUNCTION_RUNTIME = "python3.12"
+    LAMBDA_FUNCTION_TIMEOUT_SECONDS = 180  # Three minutes
+    SECRET_TAG_KEY = "tmp-influxdb-integration-test-secret"
+    ADMIN_SECRET_TAG_VALUE = "multi-user-rotation-integration-test-admin-secret"
+    USER_SECRET_TAG_VALUE = "multi-user-rotation-integration-test-user-secret"
+
+    _boto3_session: boto3.Session
+    _secrets_client = None
+    _resource_client = None
+    _lambda_client = None
+    _region_name: str
+
+    admin_secret_arn: str = ""
+    user_secret_arn: str = ""
+    rotation_lambda_name: str = ""
+    rotation_lambda_arn: str = ""
+    version_id: str = ""
+
+    def __init__(self, region_name) -> None:
+        self._region_name = region_name
+        self._boto3_session = boto3.Session(region_name=self._region_name)
+        self._secrets_client = self._boto3_session.client("secretsmanager")
+        self._resource_client = self._boto3_session.client("resourcegroupstaggingapi")
+        self._lambda_client = self._boto3_session.client("lambda")
+
+    def get_aws_resources_by_tag(self, tag_key, tag_value):
+        """
+        Returns AWS resources using its tag key and tag value.
+
+        :param str tag_key: The key of the tag.
+        :param str tag_value: The value of the tag.
+        :return: The resource information as a dict.
+        """
+        try:
+            resources = self._resource_client.get_resources(
+                TagFilters=[{"Key": tag_key, "Values": [tag_value]}]
+            )["ResourceTagMappingList"]
+            return resources
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error(
+                f"An unexpected error occurred, resources with tag {tag_key}:{tag_value} could not be retrieved"
+            )
+            raise
+
+    def create_admin_secret(
+        self, engine, username, password, token, influxdb_id, org_name
+    ):
+        """
+        Creates the admin secret dict in Secrets Manager, populating it with the provided values.
+
+        :param str engine: The type of engine, "timstream-influxdb" is typical.
+        :param str username: The username of the admin.
+        :param str password: The password for the admin.
+        :param str token: The token for the admin.
+        :param str influxdb_id: The ID of the Timestream for InfluxDB instance where the admin exists.
+        :param str org_name: The name of the existing org in the Timestream for InfluxDB instance to use.
+        :return: None
+        """
+        secret_dict = {
+            "engine": engine,
+            "username": username,
+            "password": password,
+            "token": token,
+            "static_operator_token": token,
+            "dbIdentifier": influxdb_id,
+            "org": org_name,
+        }
+        try:
+            create_admin_secret_response = self._secrets_client.create_secret(
+                Name=self.ADMIN_SECRET_TAG_VALUE + random_string(10),
+                Description="A secret used for integration tests with the InfluxDB token multi-user rotation Lambda. "
+                "This secret holds admin values, which will not be rotated.",
+                SecretString=json.dumps(secret_dict),
+                Tags=[
+                    {"Key": self.SECRET_TAG_KEY, "Value": self.ADMIN_SECRET_TAG_VALUE}
+                ],
+            )
+        except Exception:
+            logger.error("Admin secret could not be created")
+            raise
+        self.admin_secret_arn = create_admin_secret_response["ARN"]
+
+    def create_user_secret(self):
+        """
+        Creates the user secret in Secrets Manager, to be rotated, as empty JSON,
+            and sets the user_secret_arn value.
+
+        :return: None
+        """
+        try:
+            secret_dict = {}
+            create_user_secret_response = self._secrets_client.create_secret(
+                Name=self.USER_SECRET_TAG_VALUE + random_string(10),
+                Description="A secret used for integration tests with the InfluxDB token multi-user rotation Lambda. "
+                "This secret holds user values, which will be rotated.",
+                SecretString=json.dumps(secret_dict),
+                Tags=[
+                    {"Key": self.SECRET_TAG_KEY, "Value": self.USER_SECRET_TAG_VALUE}
+                ],
+            )
+        except Exception:
+            logger.error("User secret could not be created")
+            raise
+        self.user_secret_arn = create_user_secret_response["ARN"]
+
+    def init_secrets(self, engine, username, password, token, influxdb_id, org_name):
+        """
+        Initializes admin and user secrets, getting their ARNs, and creating them if needed.
+
+        :param str engine: The type of engine, "timstream-influxdb" is typical. To be used
+            to create a new admin secret if an existing admin secret cannot be found.
+        :param str username: The username of the admin. To be used
+            to create a new admin secret if an existing admin secret cannot be found.
+        :param str password: The password for the admin. To be used
+            to create a new admin secret if an existing admin secret cannot be found.
+        :param str token: The token for the admin. To be used
+            to create a new admin secret if an existing admin secret cannot be found.
+        :param str influxdb_id: The ID of the Timestream for InfluxDB instance where the admin exists. To be used
+            to create a new admin secret if an existing admin secret cannot be found.
+        :param str org_name: The name of the existing org in the Timestream for InfluxDB instance to use. To be used
+            to create a new admin secret if an existing admin secret cannot be found.
+        :return: None
+        """
+        existing_admin_secrets = self.get_aws_resources_by_tag(
+            tag_key=self.SECRET_TAG_KEY, tag_value=self.ADMIN_SECRET_TAG_VALUE
+        )
+        if len(existing_admin_secrets) > 0:
+            self.admin_secret_arn = existing_admin_secrets[0]["ResourceARN"]
+            logger.info("Existing admin secret found")
+        else:
+            logger.info("No existing admin secret could be found, creating new secret")
+            self.create_admin_secret(
+                engine, username, password, token, influxdb_id, org_name
+            )
+
+        existing_user_secrets = self.get_aws_resources_by_tag(
+            tag_key=self.SECRET_TAG_KEY, tag_value=self.USER_SECRET_TAG_VALUE
+        )
+        if len(existing_user_secrets) > 0:
+            self.user_secret_arn = existing_user_secrets[0]["ResourceARN"]
+            logger.info("Existing user secret found")
+        else:
+            logger.info("No existing user secret could be found, creating new secret")
+            self.create_user_secret()
+
+    def init_lambda_function(self, influxdb_arn):
+        """
+        Initializes the rotation lambda function, getting its ARN and name, and creating it
+            if needed.
+
+        :param str influxdb_arn: The ARN of the Timestream for InfluxDB instance, to be used to create
+            permissions for the lambda function if it doesn't already exist.
+        :return: None
+        """
+        # Check whether the lambda function already exists
+        existing_lambda_functions = self.get_aws_resources_by_tag(
+            tag_key=self.LAMBDA_FUNCTION_TAG_KEY,
+            tag_value=self.LAMBDA_FUNCTION_TAG_VALUE,
+        )
+        if len(existing_lambda_functions) > 0:
+            logger.info("Existing lambda rotation function found")
+            self.rotation_lambda_arn = existing_lambda_functions[0]["ResourceARN"]
+            try:
+                rotation_lambda = self._lambda_client.get_function(
+                    FunctionName=self.rotation_lambda_arn
+                )
+                self.rotation_lambda_name = rotation_lambda["Configuration"][
+                    "FunctionName"
+                ]
+            except Exception:
+                logger.error(
+                    f"Getting rotation lambda function name for lambda function {self.rotation_lambda_arn} failed"
+                )
+                raise
+        # Lambda function does not exist, create it
+        else:
+            logger.info("No existing rotation lambda function could be found")
+            self.create_new_lambda_function(influxdb_arn=influxdb_arn)
+
+    def create_new_lambda_function(self, influxdb_arn):
+        """
+        Creates a new rotation lambda function.
+
+        :param str influxdb_arn: The ARN of the Timestream for InfluxDB instance, to be used to
+            set permissions for the lambda function.
+        :return: None
+        """
+        # Create permissions for lambda function
+        iam_client = boto3.client("iam", region_name=self._region_name)
+        trust_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "lambda.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        lambda_role_name = self.LAMBDA_FUNCTION_TAG_VALUE + "-role" + random_string(5)
+        role_create_response = iam_client.create_role(
+            RoleName=lambda_role_name, AssumeRolePolicyDocument=json.dumps(trust_policy)
+        )
+        lambda_role_arn = role_create_response["Role"]["Arn"]
+        lambda_policy_name = (
+            self.LAMBDA_FUNCTION_TAG_VALUE + "-policy" + random_string(5)
+        )
+        account_id = boto3.client("sts").get_caller_identity().get("Account")
+        lambda_permissions = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "logs:CreateLogGroup",
+                    "Resource": f"arn:aws:logs:{self._region_name}:{account_id}:*",
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+                    "Resource": [
+                        f"arn:aws:logs:{self._region_name}:{account_id}:log-group:/aws/lambda/{self.LAMBDA_FUNCTION_TAG_VALUE}*:*"
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "secretsmanager:DescribeSecret",
+                        "secretsmanager:GetSecretValue",
+                        "secretsmanager:PutSecretValue",
+                        "secretsmanager:UpdateSecretVersionStage",
+                    ],
+                    "Resource": [f"{self.user_secret_arn}"],
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "secretsmanager:GetSecretValue",
+                    ],
+                    "Resource": [f"{self.admin_secret_arn}"],
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": ["secretsmanager:GetRandomPassword"],
+                    "Resource": "*",
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "timestream-influxdb:GetDbInstance",
+                    ],
+                    "Resource": [f"{influxdb_arn}"],
+                },
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=lambda_role_name,
+            PolicyName=lambda_policy_name,
+            PolicyDocument=json.dumps(lambda_permissions),
+        )
+
+        # Create lambda function
+        logger.info("Building lambda deployment")
+        package_command = []
+        if platform == "win32":
+            package_command = [".\\build_deployment.ps1", "-D"]
+        else:
+            package_command = ["./build_deployment.sh", "-D"]
+        subprocess.run(
+            package_command,
+            shell=False,
+            input="y\n",
+            text=True,
+            stdout=subprocess.PIPE,
+            cwd=os.path.pardir,
+        )
+        archive_path = Path("../influxdb-token-rotation-lambda.zip")
+        if not archive_path.is_file():
+            logger.error("Building rotation lambda function deployment failed")
+            return
+        logger.info("Creating lambda function")
+        self.rotation_lambda_name = self.LAMBDA_FUNCTION_TAG_VALUE + random_string(5)
+        with open(archive_path, "rb") as archive:
+            lambda_create_response = self._lambda_client.create_function(
+                FunctionName=self.rotation_lambda_name,
+                Runtime=self.LAMBDA_FUNCTION_RUNTIME,
+                Handler="lambda_function.lambda_handler",
+                Role=lambda_role_arn,
+                Timeout=self.LAMBDA_FUNCTION_TIMEOUT_SECONDS,
+                Code={"ZipFile": archive.read()},
+                PackageType="Zip",
+                Environment={
+                    "Variables": {
+                        "SECRETS_MANAGER_ENDPOINT": f"https://secretsmanager.{self._region_name}.amazonaws.com"
+                    }
+                },
+                Tags={self.LAMBDA_FUNCTION_TAG_KEY: self.LAMBDA_FUNCTION_TAG_VALUE},
+            )
+        self.rotation_lambda_arn = lambda_create_response["FunctionArn"]
+
+        self._lambda_client.put_function_concurrency(
+            FunctionName=self.rotation_lambda_name, ReservedConcurrentExecutions=100
+        )
+
+        # Allow secrets manager to invoke the lambda function
+        self._lambda_client.add_permission(
+            FunctionName=self.rotation_lambda_arn,
+            StatementId="SecretsMangerInvoke",
+            Action="lambda:InvokeFunction",
+            Principal="secretsmanager.amazonaws.com",
+            SourceArn=self.user_secret_arn,
+        )
+
+    def set_version_id(self, version_id=None):
+        """
+        Sets the version ID of the current secret, locally.
+        If version_id is not provided, a uuid is generated.
+
+        :param str version_id: The version ID to set, must be at least 32 characters in length.
+        :return: None
+        """
+        if version_id is not None:
+            self.version_id = version_id
+        else:
+            self.version_id = str(uuid.uuid4())
+
+    def cancel_rotate_user_secret(self):
+        """
+        Cancels any ongoing rotation of the user secret and removes AWSPENDING from any
+            version of the user secret.
+
+        :return: None
+        """
+        self._secrets_client.cancel_rotate_secret(SecretId=self.user_secret_arn)
+        self.remove_pending(arn=self.user_secret_arn)
+
+    def wait_for_rotation(self, arn):
+        """
+        Waits for a rotation to end, whether with success or failure.
+
+        :return: bool, whether the rotation succeeded.
+        """
+        # The only reliable way to determine whether a rotation succeeded is to check whether
+        # the version ID has been set
+        timeout = time.time() + self.ROTATION_TIMEOUT_SECONDS
+        while time.time() < timeout:
+            try:
+                self._secrets_client.get_secret_value(
+                    SecretId=arn,
+                    VersionId=self.version_id,
+                    VersionStage="AWSCURRENT",
+                )
+                return True
+            except (
+                self._secrets_client.exceptions.ResourceNotFoundException,
+                self._secrets_client.exceptions.InvalidRequestException,
+            ):
+                pass
+            time.sleep(5)
+        return False
+
+    def rotate_user_secret(self):
+        """
+        Rotates the user secret using the rotation lambda and a new version ID.
+
+        :return: bool, whether the rotation succeeded.
+        """
+        # There should not be any rotations currently in progress, removing the AWSPENDING stage
+        # will keep rotate_secret from believing a rotation is in progress
+        self.cancel_rotate_user_secret()
+        self.remove_pending(self.user_secret_arn)
+        self.set_version_id()
+        try:
+            self._secrets_client.rotate_secret(
+                SecretId=self.user_secret_arn,
+                ClientRequestToken=self.version_id,
+                RotationLambdaARN=self.rotation_lambda_arn,
+                RotateImmediately=True,
+            )
+        except (
+            self._secrets_client.exceptions.InvalidRequestException,
+            self._secrets_client.exceptions.ResourceNotFoundException,
+        ):
+            raise
+        return self.wait_for_rotation(self.user_secret_arn)
+
+    def set_create_auth(self, create_auth):
+        """
+        Sets the environment variable of the rotation lambda to allow it to create
+            credentials or tokens if necessary.
+
+        :param bool create_auth: The value to set the environment variable to.
+        :return: None
+        """
+        create_auth_str = "false"
+        if create_auth:
+            create_auth_str = "true"
+        self._lambda_client.update_function_configuration(
+            FunctionName=self.rotation_lambda_arn,
+            Environment={
+                "Variables": {
+                    "SECRETS_MANAGER_ENDPOINT": f"https://secretsmanager.{self._region_name}.amazonaws.com",
+                    "AUTHENTICATION_CREATION_ENABLED": create_auth_str,
+                }
+            },
+        )
+        # Wait for configuration to change
+        timeout = time.time() + 60  # One minute from now
+        while time.time() < timeout:
+            response = self._lambda_client.get_function_configuration(
+                FunctionName=self.rotation_lambda_arn
+            )
+            if (
+                "LastUpdateStatus" in response
+                and response["LastUpdateStatus"] == "Successful"
+            ):
+                logger.debug(
+                    f'Successfully updated create auth value to "{create_auth_str}"'
+                )
+                break
+            elif (
+                "LastUpdateStatus" in response
+                and response["LastUpdateStatus"] == "Failed"
+            ):
+                logger.error(
+                    f'Failed to udpate create auth environment variable to "{create_auth_str}"'
+                )
+                break
+            # Still in progress
+            time.sleep(5)
+        if time.time() >= timeout:
+            logger.error(
+                f'Failed to udpate create auth environment variable to "{create_auth_str}"'
+            )
+
+    def remove_pending(self, arn):
+        """
+        Removes the AWSPENDING stage from any and all version IDs for a secret.
+            The existence of an AWSPENDING stage can cause the secrets manager to consider a secret
+            still in rotation.
+
+        :param str arn: The secret ARN to remove the AWSPENDING stage from.
+        :return: None
+        """
+        try:
+            versions = self._secrets_client.describe_secret(SecretId=arn)[
+                "VersionIdsToStages"
+            ]
+            for key, val in versions.items():
+                if "AWSPENDING" in val:
+                    self._secrets_client.update_secret_version_stage(
+                        RemoveFromVersionId=key,
+                        SecretId=arn,
+                        VersionStage="AWSPENDING",
+                    )
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error("Removing AWSPENDING stage from secret version failed")
+
+    def get_admin_secret_dict(self):
+        """
+        Gets and returns the admin secret, as a dict, from Secrets Manager.
+
+        :return: dict, the admin secret.
+        """
+        return self.get_secret_dict(self.admin_secret_arn)
+
+    def get_user_secret_dict(self):
+        """
+        Gets and returns the user secret, as a dict, from Secrets Manager.
+
+        :return: dict, the user secret.
+        """
+        return self.get_secret_dict(self.user_secret_arn)
+
+    def get_secret_dict(self, secret_arn):
+        """
+        Gets and returns the secret from Secrets Manager, as a dict, with
+            matching ARN.
+        :param str secret_arn: The ARN of the secret to return.
+        :return: dict, the secret.
+        """
+        return json.loads(
+            self._secrets_client.get_secret_value(SecretId=secret_arn)["SecretString"]
+        )
+
+    def post_user_secret(self, secret_dict):
+        """
+        Updates the user secret in Amazon Secrets Manager to contain the values in secret_dict.
+
+        :param dict secret_dict: The dict to use in Secrets Manager as the user secret.
+        :return: None
+        """
+        self.post_secret(secret_dict=secret_dict, secret_arn=self.user_secret_arn)
+
+    def post_admin_secret(self, secret_dict):
+        """
+        Updates the admin secret in Amazon Secrets Manager to contain the values in secret_dict.
+
+        :param dict secret_dict: The dict to use in Secrets Manager as the admin secret.
+        :return: None
+        """
+        self.post_secret(secret_dict=secret_dict, secret_arn=self.admin_secret_arn)
+
+    def post_secret(self, secret_dict, secret_arn):
+        """
+        Updates the secret with matching ARN in Amazon Secrets Manager to contain the values in secret_dict.
+
+        :param dict secret_dict: The dict to use in Secrets Manager.
+        :param str secret_arn: The ARN of the secret to set.
+        :return: None
+        """
+        self.set_version_id()
+        try:
+            self._secrets_client.update_secret(
+                SecretId=secret_arn,
+                ClientRequestToken=self.version_id,
+                SecretString=json.dumps(secret_dict),
+            )
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error(f"Failed to update secret with ARN {secret_arn}")
+
+    def teardown(self):
+        """
+        Deletes all resources created by AWSIntegrationTestClient.
+
+        :return: None
+        """
+        self.delete_admin_secret()
+        self.delete_user_secret()
+        self.delete_lambda()
+
+    def delete_admin_secret(self):
+        """
+        Finds and deletes the admin secret in Secrets Manager by using its ARN.
+
+        :return: None
+        """
+        logger.info("Deleting admin secret")
+        self.delete_secret(secret_arn=self.admin_secret_arn)
+
+    def delete_user_secret(self):
+        """
+        Finds and deletes the user secret in Secrets Manager by using its ARN.
+
+        :return: None
+        """
+        logger.info("Deleting user secret")
+        self.delete_secret(secret_arn=self.user_secret_arn)
+
+    def delete_secret(self, secret_arn):
+        """
+        Finds and deletes a secret in Secrets Manager by using its ARN.
+
+        :param str secret_arn: The ARN of the secret to delete.
+        :return: None
+        """
+        try:
+            self._secrets_client.delete_secret(
+                SecretId=secret_arn, ForceDeleteWithoutRecovery=True
+            )
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error(f"Failed to delete secret with ARN {secret_arn}")
+
+    def delete_lambda(self):
+        """
+        Finds and deletes the rotation lambda using its name.
+
+        :return: None
+        """
+        logger.info("Deleting lambda function")
+        try:
+            self._lambda_client.delete_function(FunctionName=self.rotation_lambda_arn)
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error("Failed to delete lambda function")

--- a/SecretsManagerInfluxDBMultiUserRotation/integration/influxdb_integration_test_client.py
+++ b/SecretsManagerInfluxDBMultiUserRotation/integration/influxdb_integration_test_client.py
@@ -1,0 +1,674 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+from contextlib import contextmanager
+import json
+import time
+import os
+import sys
+
+import boto3
+from botocore.exceptions import ClientError
+import influxdb_client
+from influxdb_client.rest import ApiException
+from integration_test_utils import random_string, logger
+
+sys.path.insert(1, os.path.realpath(os.path.pardir))
+from lambda_function import create_operator_token_perms
+
+
+class InfluxDBIntegrationTestClient:
+    SLEEP_SECONDS = 15
+    MAXIMUM_WAIT_SECONDS = 1200  # 20 minutes
+    TIMESTREAM_INFLUXDB_ENGINE = "timestream-influxdb"
+    TOKEN_TYPE_ALL_ACCESS = "allAccess"
+    TOKEN_TYPE_CUSTOM = "custom"
+    TOKEN_TYPE_OPERATOR = "operator"
+    NON_EXISTENT_USERNAME = "gregstopher"
+    VPC_TAG_KEY = "tmp-influxdb-integration-test-vpc"
+    INFLUXDB_INSTANCE_TAG_KEY = "tmp-influxdb-integration-test-db"
+    INFLUXDB_INSTANCE_TAG_VALUE = "multi-user-rotation-integration-db"
+    INFLUXDB_ADMIN_USERNAME = "admin"
+    INFLUXDB_ORG_NAME = "org"
+    INFLUXDB_SECONDARY_ORG_NAME = "secondary-org"
+    INFLUXDB_BUCKET = "test-bucket"
+    INFLUXDB_TYPE = "db.influx.medium"
+    _region_name: str
+    _boto3_session = None
+    _resource_client = None
+    _timestream_influxdb_client = None
+    _secrets_client = None
+    _ec2 = None
+    _ec2_client = None
+
+    # influxdb_client must be accessed and closed by integration_test
+    # because influxdb_client.__del__ does an import during program shutdown
+    # which causes alarming logs
+    influxdb_client = None
+    current_auth = None
+    static_operator_token: str = ""
+    influxdb_admin_id: str = ""
+    influxdb_admin_password: str = ""
+    influxdb_arn: str = ""
+    influxdb_endpoint: str = ""
+    influxdb_id: str = ""
+    influxdb_org_id: str = ""
+    influxdb_secondary_org_id: str = ""
+    vpc_id: str = ""
+
+    def __init__(self, region_name) -> None:
+        self._region_name = region_name
+        self._boto3_session = boto3.Session(region_name=self._region_name)
+        self._resource_client = self._boto3_session.client("resourcegroupstaggingapi")
+        self._timestream_influxdb_client = self._boto3_session.client(
+            "timestream-influxdb"
+        )
+        self._secrets_client = self._boto3_session.client("secretsmanager")
+        self._ec2 = self._boto3_session.resource("ec2", region_name=self._region_name)
+        self._ec2_client = self._ec2.meta.client
+
+    def get_influxdb_resources_by_tag(self, tag_key, tag_value):
+        """
+        Returns Timestream for InfluxDB resources using its tag key and tag value.
+
+        :param str tag_key: The key of the tag.
+        :param str tag_value: The value of the tag.
+        :return: The resource information as a dict.
+        """
+        try:
+            resources = self._resource_client.get_resources(
+                TagFilters=[{"Key": tag_key, "Values": [tag_value]}]
+            )["ResourceTagMappingList"]
+            return resources
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error(
+                f"An unexpected error occurred, resources with tag {tag_key}:{tag_value} could not be retrieved"
+            )
+            raise
+
+    def init_timestream_for_influxdb(self):
+        """
+        Initializes Timestream for InfluxDB, creating a Timestream for InfluxDB instance
+            if needed, along with its VPC.
+
+        :return: None
+        """
+        # Test whether instance already exists
+        existing_test_dbs = self.get_influxdb_resources_by_tag(
+            tag_key=self.INFLUXDB_INSTANCE_TAG_KEY,
+            tag_value=self.INFLUXDB_INSTANCE_TAG_VALUE,
+        )
+        if len(existing_test_dbs) > 0:
+            logger.info("Existing Timestream for InfluxDB instance found")
+            self.influxdb_arn = existing_test_dbs[0]["ResourceARN"]
+            self.use_existing_timestream_influxdb_instance()
+        # Test instance does not exist, create it
+        else:
+            logger.info("No existing Timestream for InfluxDB instance could be found")
+            self.create_new_timestream_influxdb_instance()
+
+    def use_existing_timestream_influxdb_instance(self):
+        """
+        Populates AWS values associated with the Timestream for InfluxDB test
+            instance, such as its ID, endpoint, stored password, and ARN.
+
+        :return: None
+        """
+        try:
+            instances = self._timestream_influxdb_client.list_db_instances()
+
+            for instance in instances["items"]:
+                if instance["arn"] == self.influxdb_arn:
+                    self.influxdb_id = instance["id"]
+            while self.influxdb_id == "" and instances["nextToken"] != "":
+                for instance in instances["items"]:
+                    if instance["arn"] == self.influxdb_arn:
+                        self.influxdb_id = instance["id"]
+                instances = self._timestream_influxdb_client.list_db_instances(
+                    nextToken=instances["nextToken"]
+                )
+            if self.influxdb_id == "":
+                raise ValueError(
+                    "ERROR: Metadata for existing Timestream for InfluxDB instance could not be retrieved"
+                )
+            instance_secret_arn = self._timestream_influxdb_client.get_db_instance(
+                identifier=self.influxdb_id
+            )["influxAuthParametersSecretArn"]
+            self.influxdb_admin_password = json.loads(
+                self._secrets_client.get_secret_value(SecretId=instance_secret_arn)[
+                    "SecretString"
+                ]
+            )["password"]
+
+            self.influxdb_endpoint = self._timestream_influxdb_client.get_db_instance(
+                identifier=self.influxdb_id
+            )["endpoint"]
+
+            self.get_default_influxdb_metadata()
+            # Get secondary org ID
+            orgs = self.influxdb_client.organizations_api().find_organizations(
+                org=self.INFLUXDB_SECONDARY_ORG_NAME
+            )
+            if len(orgs) < 1:
+                raise ValueError("Secondary org could not be found")
+            self.influxdb_secondary_org_id = orgs[0].id
+        except Exception as error:
+            logger.error(repr(error))
+            raise
+
+    def create_new_timestream_influxdb_instance(self):
+        """
+        Creates a new test Timestream for InfluxDB instance, including its
+            VPC.
+
+        :return: None
+        """
+        try:
+            vpc_create_response = self._ec2_client.create_vpc(
+                CidrBlock="10.0.0.0/16", AmazonProvidedIpv6CidrBlock=False
+            )
+            vpc_id = vpc_create_response["Vpc"]["VpcId"]
+            self._ec2_client.create_tags(
+                Resources=[vpc_id],
+                Tags=[
+                    {"Key": "Name", "Value": "influxdb-integration-vpc"},
+                    {
+                        "Key": self.VPC_TAG_KEY,
+                        "Value": self.INFLUXDB_INSTANCE_TAG_VALUE,  # Tag to help deletion later
+                    },
+                ],
+            )
+            logger.info(f"Created VPC with ID {vpc_id}")
+            self._ec2_client.modify_vpc_attribute(
+                VpcId=vpc_id,
+                EnableDnsSupport={"Value": True},
+            )
+            self._ec2_client.modify_vpc_attribute(
+                VpcId=vpc_id, EnableDnsHostnames={"Value": True}
+            )
+            ig_create_response = self._ec2_client.create_internet_gateway()
+            ig_id = ig_create_response["InternetGateway"]["InternetGatewayId"]
+            self._ec2_client.attach_internet_gateway(
+                InternetGatewayId=ig_id, VpcId=vpc_id
+            )
+            subnet_response = self._ec2_client.create_subnet(
+                VpcId=vpc_id,
+                CidrBlock="10.0.0.0/24",
+                AvailabilityZone=f"{self._region_name}a",
+            )
+            subnet_id = subnet_response["Subnet"]["SubnetId"]
+            route_table_create_response = self._ec2_client.create_route_table(
+                VpcId=vpc_id
+            )
+            self._ec2_client.create_route(
+                RouteTableId=route_table_create_response["RouteTable"]["RouteTableId"],
+                DestinationCidrBlock="0.0.0.0/0",
+                GatewayId=ig_id,
+            )
+            self._ec2_client.associate_route_table(
+                RouteTableId=route_table_create_response["RouteTable"]["RouteTableId"],
+                SubnetId=subnet_id,
+            )
+            security_group_response = self._ec2_client.create_security_group(
+                Description=f"VPC security group for {self.INFLUXDB_INSTANCE_TAG_VALUE}",
+                GroupName=self.INFLUXDB_INSTANCE_TAG_VALUE,
+                VpcId=vpc_id,
+            )
+            security_group_id = security_group_response["GroupId"]
+            self._ec2_client.authorize_security_group_ingress(
+                GroupId=security_group_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 8086,
+                        "ToPort": 8086,
+                        "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                    }
+                ],
+            )
+        except Exception:
+            logger.error("Failed to create VPC and VPC dependencies")
+            raise
+
+        self.influxdb_admin_password = random_string(20)
+
+        logger.info("Creating new Timestream for InfluxDB instance")
+        try:
+            instance = self._timestream_influxdb_client.create_db_instance(
+                name=self.INFLUXDB_INSTANCE_TAG_VALUE + random_string(3),
+                username=self.INFLUXDB_ADMIN_USERNAME,
+                password=self.influxdb_admin_password,
+                organization=self.INFLUXDB_ORG_NAME,
+                bucket=self.INFLUXDB_BUCKET,
+                dbInstanceType=self.INFLUXDB_TYPE,
+                vpcSubnetIds=[subnet_id],
+                vpcSecurityGroupIds=[security_group_id],
+                publiclyAccessible=True,
+                dbStorageType="InfluxIOIncludedT1",
+                allocatedStorage=20,
+                deploymentType="SINGLE_AZ",
+                tags={self.INFLUXDB_INSTANCE_TAG_KEY: self.INFLUXDB_INSTANCE_TAG_VALUE},
+            )
+        except Exception:
+            logger.error("Failed to create Timestream for InfluxDB instance")
+            raise
+
+        self.influxdb_arn = instance["arn"]
+
+        self.influxdb_id = instance["id"]
+
+        try:
+            instance = self._timestream_influxdb_client.get_db_instance(
+                identifier=self.influxdb_id
+            )
+        except Exception:
+            logger.error("Failed to get new Timestream for InfluxDB instance")
+            raise
+
+        elapsed_time = 0
+        while (
+            instance["status"] == "CREATING"
+            and elapsed_time < self.MAXIMUM_WAIT_SECONDS
+        ):
+            time.sleep(self.SLEEP_SECONDS)
+            elapsed_time += self.SLEEP_SECONDS
+            instance = self._timestream_influxdb_client.get_db_instance(
+                identifier=self.influxdb_id
+            )
+            logger.info(f"Creation status: {instance['status']}")
+        if (
+            elapsed_time >= self.MAXIMUM_WAIT_SECONDS
+            and instance["status"] != "AVAILABLE"
+        ):
+            raise ValueError("A Timestream for InfluxDB instance could not be created")
+        else:
+            logger.info(
+                f"New Timestream for InfluxDB instance created with endpoint {instance['endpoint']}, status: {instance['status']}"
+            )
+            # Using an instance too soon can cause issues
+            time.sleep(30)
+            instance = self._timestream_influxdb_client.get_db_instance(
+                identifier=self.influxdb_id
+            )
+
+        logger.info("Getting endpoint")
+        self.influxdb_endpoint = instance["endpoint"]
+        self.get_default_influxdb_metadata()
+        logger.info("Creating secondary org")
+        secondary_org = self.influxdb_client.organizations_api().create_organization(
+            name=self.INFLUXDB_SECONDARY_ORG_NAME
+        )
+        self.influxdb_secondary_org_id = secondary_org.id
+
+    def get_default_influxdb_metadata(self):
+        """
+        Gets default Timestream for InfluxDB metadata, such as admin user ID,
+            operator token, and primary org ID, using the InfluxDB client.
+
+        :return: None
+        """
+        try:
+            self.influxdb_client = influxdb_client.InfluxDBClient(
+                url=f"https://{self.influxdb_endpoint}:8086",
+                username=self.INFLUXDB_ADMIN_USERNAME,
+                password=self.influxdb_admin_password,
+                org=self.INFLUXDB_ORG_NAME,
+            )
+
+            users = self.influxdb_client.users_api().find_users(
+                name=self.INFLUXDB_ADMIN_USERNAME
+            )
+            if len(users.users) < 1:
+                raise ValueError("Admin user ID could not be found")
+            self.influxdb_admin_id = users.users[0].id
+
+            orgs = self.influxdb_client.organizations_api().find_organizations(
+                org=self.INFLUXDB_ORG_NAME
+            )
+            if len(orgs) < 1:
+                raise ValueError("Primary org could not be found")
+            self.influxdb_org_id = orgs[0].id
+
+            auths = self.influxdb_client.authorizations_api().find_authorizations(
+                org=self.INFLUXDB_ORG_NAME
+            )
+
+            for auth in auths:
+                # The first token, created when the instance is first created,
+                # will have the following description
+                if auth.description == f"{self.INFLUXDB_ADMIN_USERNAME}'s Token":
+                    self.static_operator_token = auth.token
+            if self.static_operator_token == "":
+                raise ValueError(
+                    "The static operator token could not be retrieved from the Timestream for InfluxDB instance"
+                )
+        except Exception as error:
+            logger.error(repr(error))
+            raise
+
+    def create_current_auth(self, token_perms=None):
+        """
+        Creates a new token in Timestream for InfluxDB and sets
+            InfluxDBIntegrationTestClient.current_auth to this new authorization.
+
+        :param list[influxdb_client.Permission]: A list of Permissions to use to create
+            the authorization.
+        :return: None
+        """
+        if token_perms is None:
+            token_perms = create_operator_token_perms()
+        try:
+            self.current_auth = (
+                self.influxdb_client.authorizations_api().create_authorization(
+                    org_id=self.influxdb_org_id, permissions=token_perms
+                )
+            )
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error("Failed to create new Timestream for InfluxDB token")
+
+    def teardown(self):
+        """
+        Deletes all Timestream for InfluxDB resources, including the Timestream for InfluxDB
+            instance and its VPC.
+
+        :return: None
+        """
+        self.delete_influxdb_instance()
+        # Delete test VPCs as deleting a Timestream for InfluxDB instance won't delete its VPCs
+        # VPCs can only be deleted after the instance has been deleted
+        existing_test_vpcs = self.get_influxdb_resources_by_tag(
+            tag_key=self.VPC_TAG_KEY, tag_value=self.INFLUXDB_INSTANCE_TAG_VALUE
+        )
+        if len(existing_test_vpcs) > 0:
+            for vpc in existing_test_vpcs:
+                vpc_id = vpc["ResourceARN"].split("/")[-1]
+                self.delete_vpc_and_dependencies(vpc_id=vpc_id)
+
+    def delete_influxdb_instance(self):
+        """
+        Deletes the test Timestream for InfluxDB instance. This method will wait
+            for the instance to finish deleting.
+
+        :return: None
+        """
+        logger.info(f"Deleting Timestream for InfluxDB instance {self.influxdb_id}")
+        try:
+            self._timestream_influxdb_client.delete_db_instance(
+                identifier=self.influxdb_id
+            )
+        except Exception:
+            raise
+        try:
+            instance = self._timestream_influxdb_client.get_db_instance(
+                identifier=self.influxdb_id
+            )
+            elapsed_time = 0
+            while (
+                instance["status"] == "DELETING"
+                and elapsed_time < self.MAXIMUM_WAIT_SECONDS
+            ):
+                time.sleep(self.SLEEP_SECONDS)
+                elapsed_time += self.SLEEP_SECONDS
+                instance = self._timestream_influxdb_client.get_db_instance(
+                    identifier=self.influxdb_id
+                )
+                logger.info(f"Deletion status: {instance['status']}")
+            if (
+                elapsed_time >= self.MAXIMUM_WAIT_SECONDS
+                and instance["status"] == "DELETING"
+            ):
+                logger.error(
+                    f"Failed to delete Timestream for InfluxDB instance {self.influxdb_id}"
+                )
+        # get_db_instance will throw a ResourceNotFoundException when the instance is finished deleting
+        except self._timestream_influxdb_client.exceptions.ResourceNotFoundException:
+            logger.info("Timestream for InfluxDB instance deleted")
+
+    def delete_vpc_and_dependencies(self, vpc_id):
+        """
+        Deletes the Timestream for InfluxDB VPC and all of its associated resources.
+
+        :return: None
+        """
+        try:
+            vpc = self._ec2.Vpc(vpc_id)
+
+            # Delete transit gateway attachments
+            for attachment in self._ec2_client.describe_transit_gateway_attachments()[
+                "TransitGatewayAttachments"
+            ]:
+                if attachment["ResourceId"] == vpc_id:
+                    self._ec2_client.delete_transit_gateway_vpc_attachment(
+                        TransitGatewayAttachmentId=attachment[
+                            "TransitGatewayAttachmentId"
+                        ]
+                    )
+
+            # Delete NAT gateways
+            filters = [{"Name": "vpc-id", "Values": [vpc_id]}]
+            for nat_gateway in self._ec2_client.describe_nat_gateways(Filters=filters)[
+                "NatGateways"
+            ]:
+                self._ec2_client.delete_nat_gateway(
+                    NatGatewayId=nat_gateway["NatGatewayId"]
+                )
+
+            # Detach default DHCP options
+            dhcp_default_options = self._ec2.DhcpOptions("default")
+            if dhcp_default_options:
+                dhcp_default_options.associate_with_vpc(VpcId=vpc_id)
+
+            # Delete gateways
+            for gateway in vpc.internet_gateways.all():
+                vpc.detach_internet_gateway(InternetGatewayId=gateway.id)
+                gateway.delete()
+
+            # Delete any VPC peering connections
+            request_peers = self._ec2_client.describe_vpc_peering_connections(
+                Filters=[{"Name": "requester-vpc-info.vpc-id", "Values": [vpc_id]}]
+            )
+            accept_peers = self._ec2_client.describe_vpc_peering_connections(
+                Filters=[{"Name": "accepter-vpc-info.vpc-id", "Values": [vpc_id]}]
+            )
+            for peer in request_peers["VpcPeeringConnections"]:
+                self._ec2.VpcPeeringConnection(peer["VpcPeeringConnectionId"]).delete()
+            for peer in accept_peers["VpcPeeringConnections"]:
+                self._ec2.VpcPeeringConnection(peer["VpcPeeringConnectionId"]).delete()
+
+            # Delete endpoints
+            endpoints = self._ec2_client.describe_vpc_endpoints(
+                Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]
+            )
+            for endpoint in endpoints["VpcEndpoints"]:
+                self._ec2_client.delete_vpc_endpoints(
+                    VpcEndpointIds=endpoint["VpcEndpointId"]
+                )
+
+            # Delete security groups
+            for security_group in vpc.security_groups.all():
+                if security_group.group_name != "default":
+                    security_group.delete()
+
+            # Delete non-default network ACLs
+            for net_acl in vpc.network_acls.all():
+                if not net_acl.is_default:
+                    net_acl.delete()
+
+            try:
+                # Delete route tables and route table associations
+                filters = [{"Name": "vpc-id", "Values": [vpc_id]}]
+                route_tables = self._ec2_client.describe_route_tables(Filters=filters)[
+                    "RouteTables"
+                ]
+                for route_table in route_tables:
+                    for route in route_table["Routes"]:
+                        if route["Origin"] == "CreateRoute":
+                            self._ec2_client.delete_route(
+                                RouteTableId=route_table["RouteTableId"],
+                                DestinationCidrBlock=route["DestinationCidrBlock"],
+                            )
+                        for association in route_table["Associations"]:
+                            if not association["Main"]:
+                                self._ec2_client.disassociate_route_table(
+                                    AssociationId=association["RouteTableAssociationId"]
+                                )
+                                self._ec2_client.delete_route_table(
+                                    RouteTableId=route_table["RouteTableId"]
+                                )
+                for route_table in route_tables:
+                    if route_table["Associations"] == []:
+                        self._ec2_client.delete_route_table(
+                            RouteTableId=route_table["RouteTableId"]
+                        )
+            except ClientError:
+                # An exception will be raised for a route not having a DestinationCidrBlock of 0.0.0.0/0
+                # this can be ignored
+                pass
+
+            # Delete subnets and network interfaces
+            for subnet in vpc.subnets.all():
+                for interface in subnet.network_interfaces.all():
+                    interface.delete()
+                for instance in subnet.instances.all():
+                    filters = [{"Name": "instance-id", "Values": [instance.id]}]
+                    eips = self._ec2_client.describe_addresses(Filters=filters)[
+                        "Addresses"
+                    ]
+                    for eip in eips:
+                        self._ec2_client.disassociate_address(
+                            AssociationId=eip["AssociationId"]
+                        )
+                        self._ec2_client.release_address(
+                            AllocationId=eip["AllocationId"]
+                        )
+                subnet.delete()
+
+            # Delete instances
+            filters = [
+                {"Name": "instance-state-name", "Values": ["running"]},
+                {"Name": "vpc-id", "Values": [vpc_id]},
+            ]
+            ec2_instances = self._ec2_client.describe_instances(Filters=filters)
+            instance_ids = []
+            for reservation in ec2_instances["Reservations"]:
+                instance_ids += [
+                    instance["InstanceId"] for instance in reservation["Instances"]
+                ]
+            if len(instance_ids) > 0:
+                waiter = self._ec2_client.get_waiter("instance_terminated")
+                self._ec2_client.terminate_instances(InstanceIds=instance_ids)
+                waiter.wait(InstanceIds=instance_ids)
+
+            # Delete VPC
+            self._ec2_client.delete_vpc(VpcId=vpc_id)
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error("Failed to delete VPC and dependencies")
+
+    def delete_non_admin_tokens(self):
+        """
+        Deletes all tokens in the Timestream for InfluxDB instance that does not
+            match the current static operator token.
+
+        :return: None
+        """
+        try:
+            auths = self.influxdb_client.authorizations_api().find_authorizations(
+                org_id=self.influxdb_org_id
+            )
+            for auth in auths:
+                if auth.token != self.static_operator_token:
+                    self.influxdb_client.authorizations_api().delete_authorization(auth)
+        except ApiException as error:
+            logger.error(repr(error))
+
+    def reset_admin_password(self):
+        """
+        Resets the admin password in Timestream for InfluxDB to the password
+            set in init_timestream_for_influxdb.
+
+        :return: None
+        """
+        self.influxdb_client.users_api().update_password(
+            user=self.influxdb_admin_id, password=self.influxdb_admin_password
+        )
+
+    def reset_non_existent_user(self):
+        """
+        Ensures the non-existent user, needed for testing, remains non-existent by
+            deleting this user if it exists in the Timestream for InfluxDB instance.
+
+        :return: None
+        """
+        try:
+            users = (
+                self.influxdb_client.users_api()
+                .find_users(name=self.NON_EXISTENT_USERNAME)
+                .users
+            )
+            if users is not None:
+                for user in users:
+                    self.influxdb_client.users_api().delete_user(user)
+        except ApiException:
+            pass
+
+    def get_primary_org(self, token):
+        """
+        Gets the primary org from Timestream for InfluxDB.
+
+        :param str token: The token to use to get the org.
+        :return: A list of influxdb_client.domain.organization.Organization objects
+            with the same org ID as the primary org.
+        """
+        with self.get_connection_using_token(token) as conn:
+            return self.get_orgs(conn, self.influxdb_org_id)
+
+    def get_secondary_org(self, token):
+        """
+        Gets the secondary org from Timestream for InfluxDB.
+
+        :param str token: The token to use to get the org.
+        :return: A list of influxdb_client.domain.organization.Organization objects
+            with the same org ID as the secondary org.
+        """
+        with self.get_connection_using_token(token) as conn:
+            return self.get_orgs(conn, self.influxdb_secondary_org_id)
+
+    def get_orgs(self, test_influxdb_client, org_id):
+        """
+        Gets orgs using test_influxdb_client with org ID matching org_id.
+
+        :param influxdb_client.InfluxDBClient test_influxdb_client:
+            The InfluxDB client to use to get the orgs.
+        :param str org_id: The ID of the org to get.
+        :return: A list of influxdb_client.domain.organization.Organization objects
+            with the same org ID as org_id.
+        """
+        return test_influxdb_client.organizations_api().find_organizations(
+            org_id=org_id
+        )
+
+    @contextmanager
+    def get_connection_using_token(self, token):
+        """
+        Creates a new InfluxDBClient using the given token.
+
+        :param str token: The InfluxDB token to use to create an InfluxDB client.
+        :return: An InfluxDB client connection.
+        """
+        conn = None
+        try:
+            conn = influxdb_client.InfluxDBClient(
+                url=f"https://{self.influxdb_endpoint}:8086",
+                token=token,
+                debug=False,
+                verify_ssl=True,
+            )
+            yield conn
+        except Exception as err:
+            raise ValueError("Error getting connection") from err
+        finally:
+            if conn is not None:
+                conn.close()

--- a/SecretsManagerInfluxDBMultiUserRotation/integration/integration_test.py
+++ b/SecretsManagerInfluxDBMultiUserRotation/integration/integration_test.py
@@ -1,0 +1,604 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import argparse
+import os
+import sys
+import unittest
+
+from aws_integration_test_client import AWSIntegrationTestClient
+from influxdb_integration_test_client import InfluxDBIntegrationTestClient
+
+sys.path.insert(1, os.path.realpath(os.path.pardir))
+from lambda_function import (
+    create_all_access_token_perms,
+    create_custom_token_perms,
+)
+from integration_test_utils import logger
+
+aws_region_name = ""
+
+# Whether to delete all AWS resources after testing
+cleanup = False
+
+
+class BaseTestCases:
+    class BaseTestCase(unittest.TestCase):
+        user_secret_dict = {}
+        aws_it_client: AWSIntegrationTestClient
+        influxdb_it_client: InfluxDBIntegrationTestClient
+
+        @classmethod
+        def setUpClass(cls):
+            cls.aws_it_client = AWSIntegrationTestClient(region_name=aws_region_name)
+            cls.influxdb_it_client = InfluxDBIntegrationTestClient(
+                region_name=aws_region_name
+            )
+            try:
+                cls.influxdb_it_client.init_timestream_for_influxdb()
+                cls.aws_it_client.init_secrets(
+                    engine=cls.influxdb_it_client.TIMESTREAM_INFLUXDB_ENGINE,
+                    username=cls.influxdb_it_client.INFLUXDB_ADMIN_USERNAME,
+                    password=cls.influxdb_it_client.influxdb_admin_password,
+                    token=cls.influxdb_it_client.static_operator_token,
+                    influxdb_id=cls.influxdb_it_client.influxdb_id,
+                    org_name=cls.influxdb_it_client.INFLUXDB_ORG_NAME,
+                )
+                cls.aws_it_client.init_lambda_function(
+                    influxdb_arn=cls.influxdb_it_client.influxdb_arn
+                )
+            except Exception as error:
+                logger.error(repr(error))
+                logger.error("Test initialization failed. Exiting . . .")
+                exit(1)
+
+        def setUp(self):
+            """
+            Overrides unittest.TestCase.setUp, called before each test runs
+            """
+            assert self.aws_it_client is not None
+            assert self.influxdb_it_client is not None
+            # Create a new InfluxDB token and initialize self.user_secret_dict to default values
+            self.influxdb_it_client.create_current_auth()
+            self.set_user_secret_dict(
+                token_type=self.influxdb_it_client.TOKEN_TYPE_OPERATOR,
+                token=self.influxdb_it_client.current_auth.token,
+            )
+            # Stop a rotation if it was left in progress
+            self.aws_it_client.cancel_rotate_user_secret()
+
+        def set_user_secret_dict(
+            self,
+            operator_token_arn=None,
+            db_identifier=None,
+            org_name=None,
+            token_type=None,
+            token=None,
+            write_bucket=None,
+            read_bucket=None,
+            permissions=None,
+            username=None,
+            password=None,
+        ):
+            # Mandatory fields
+            secret_dict = {
+                "engine": self.influxdb_it_client.TIMESTREAM_INFLUXDB_ENGINE,
+                "operatorTokenArn": operator_token_arn
+                if operator_token_arn is not None
+                else self.aws_it_client.admin_secret_arn,
+                "dbIdentifier": db_identifier
+                if db_identifier is not None
+                else self.influxdb_it_client.influxdb_id,
+                "org": org_name
+                if org_name is not None
+                else self.influxdb_it_client.INFLUXDB_ORG_NAME,
+            }
+            if token_type is not None:
+                secret_dict["type"] = token_type
+            if token is not None:
+                secret_dict["token"] = token
+            if permissions is not None:
+                secret_dict["permissions"] = permissions
+            if read_bucket is not None:
+                secret_dict["readBucket"] = read_bucket
+            if write_bucket is not None:
+                secret_dict["writeBucket"] = write_bucket
+            if username is not None:
+                secret_dict["username"] = username
+            if password is not None:
+                secret_dict["password"] = password
+            self.user_secret_dict = secret_dict
+
+        def assert_token_is_scoped_to_primary_org(self, token):
+            self.assertGreater(
+                len(self.influxdb_it_client.get_primary_org(token=token)), 0
+            )
+            self.assertEqual(
+                len(self.influxdb_it_client.get_secondary_org(token=token)), 0
+            )
+
+        def tearDown(self):
+            """
+            Overrides unittest.TestCase.tearDown, called after each test runs
+
+            Resets the admin secret to default values, resets the admin's password in Timestream for InfluxDB,
+            ensures the non-existent user stays non-existent, and deletes any token that is not the admin's token.
+            """
+            if self.aws_it_client is not None:
+                # Stop a rotation if it was left in progress
+                self.aws_it_client.cancel_rotate_user_secret()
+                # Reset admin token value to an authenticated token
+                admin_secret_dict = self.aws_it_client.get_admin_secret_dict()
+                admin_secret_dict["token"] = (
+                    self.influxdb_it_client.static_operator_token
+                )
+                self.aws_it_client.set_version_id()
+                self.aws_it_client.post_admin_secret(secret_dict=admin_secret_dict)
+                self.aws_it_client.set_create_auth(False)
+            if self.influxdb_it_client is not None:
+                self.influxdb_it_client.reset_admin_password()
+                # The non-existent user must remain non-existent
+                self.influxdb_it_client.reset_non_existent_user()
+                self.influxdb_it_client.delete_non_admin_tokens()
+
+        @classmethod
+        def tearDownClass(cls):
+            if cls.influxdb_it_client.influxdb_client is not None:
+                cls.influxdb_it_client.influxdb_client.close()
+            if cleanup:
+                cls.aws_it_client.teardown()
+                cls.influxdb_it_client.teardown()
+
+
+class SecretsTestCase(BaseTestCases.BaseTestCase):
+    def test_operator_token_rotation_no_token(self):
+        """
+        Failure rotation for operator token without token provided.
+        """
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_OPERATOR
+        )
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_secret_dict = self.aws_it_client.get_user_secret_dict()
+        self.assertNotIn("token", new_secret_dict)
+
+    def test_random_operator_token_rotation(self):
+        """
+        Failure rotation for random operator token.
+        """
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_OPERATOR, token="random-token"
+        )
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertEqual(old_token, new_token)
+
+    def test_retrigger_random_operator_token_rotation(self):
+        """
+        Failure re-rotation random operator token.
+        """
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_OPERATOR, token="random-token"
+        )
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+
+        # First rotation
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertEqual(old_token, new_token)
+
+        # Second rotation
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertEqual(old_token, new_token)
+
+    def test_operator_token_rotation_invalid_operator_token_arn(self):
+        """
+        Failure rotation with invalid operatorTokenArn.
+        """
+        invalid_arn = "invalid-arn-for-admin-secret"
+        self.user_secret_dict["operatorTokenArn"] = invalid_arn
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+        self.aws_it_client.set_create_auth(True)
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertEqual(old_token, new_token)
+
+    def test_all_access_token_rotation_no_token_create_auth_disabled(self):
+        """
+        Failure rotation for all access token with missing token and create auth disabled.
+        """
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_ALL_ACCESS
+        )
+        # Set the user secret using the new all access token
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_secret_dict = self.aws_it_client.get_user_secret_dict()
+        self.assertNotIn("token", new_secret_dict)
+
+    def test_all_access_token_rotation_escalate_to_operator(self):
+        """
+        Failure to escalate an all access token to an operator token.
+        """
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_ALL_ACCESS
+        )
+        # Set the user secret using the new all access token
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        self.aws_it_client.set_create_auth(True)
+        # Rotation should succeed, the escalation of privileges should fail
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_secret_dict = self.aws_it_client.get_user_secret_dict()
+        self.assertIn("token", new_secret_dict)
+        new_token = new_secret_dict["token"]
+
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_OPERATOR, token=new_token
+        )
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertNotEqual(old_token, new_token)
+
+        # All access tokens will have permissions scoped to an organization
+        # if the token cannot be used to get information about another organization, then it has not
+        # been escalated to an operator token
+        self.assert_token_is_scoped_to_primary_org(token=new_token)
+
+    def test_username_and_password_rotation_non_existent_user_create_auth_disabled(
+        self,
+    ):
+        """
+        Failure to rotate credentials for non-existent user with create auth disabled.
+        """
+        self.set_user_secret_dict(
+            username=self.influxdb_it_client.NON_EXISTENT_USERNAME
+        )
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_secret_dict = self.aws_it_client.get_user_secret_dict()
+        self.assertNotIn("password", new_secret_dict)
+
+    def test_username_and_password_rotation_incorrect_password(self):
+        """
+        Wrong password set for user fails.
+        """
+        self.set_user_secret_dict(
+            username=self.influxdb_it_client.INFLUXDB_ADMIN_USERNAME,
+            password="incorrect-password",
+        )
+        old_password = self.user_secret_dict["password"]
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_password = self.aws_it_client.get_user_secret_dict()["password"]
+        self.assertEqual(old_password, new_password)
+
+    def test_operator_token_rotation_missing_mandatory_fields(self):
+        """
+        Failures for token rotation without mandatory secret fields.
+
+        Mandatory secret fields are "engine," "org," "dbIdentifier," "token," and "operatorTokenArn."
+        """
+        self.user_secret_dict.pop("engine", None)
+        self.user_secret_dict.pop("dbIdentifier", None)
+        self.user_secret_dict.pop("org", None)
+        self.user_secret_dict.pop("operatorTokenArn", None)
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertEqual(old_token, new_token)
+
+        self.user_secret_dict["engine"] = (
+            self.influxdb_it_client.TIMESTREAM_INFLUXDB_ENGINE
+        )
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertEqual(old_token, new_token)
+
+        self.user_secret_dict["dbIdentifier"] = self.influxdb_it_client.influxdb_id
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertEqual(old_token, new_token)
+
+        self.user_secret_dict["operatorTokenArn"] = self.aws_it_client.admin_secret_arn
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertEqual(old_token, new_token)
+
+        self.user_secret_dict["org"] = self.influxdb_it_client.INFLUXDB_ORG_NAME
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        # Note the inclusion of our generated version ID, as it should now be used as AWSCURRENT
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertNotEqual(old_token, new_token)
+
+    def test_username_and_password_rotation_missing_mandatory_fields(self):
+        """
+        Failures for credential rotation without mandatory secret fields.
+
+        Mandatory secret fields are "engine," "dbIdentifier," "username," "password," and "operatorTokenArn."
+        """
+        self.set_user_secret_dict(
+            password=self.influxdb_it_client.influxdb_admin_password
+        )
+        self.user_secret_dict.pop("engine", None)
+        self.user_secret_dict.pop("dbIdentifier", None)
+        self.user_secret_dict.pop("username", None)
+        self.user_secret_dict.pop("operatorTokenArn", None)
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_password = self.user_secret_dict["password"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_password = self.aws_it_client.get_user_secret_dict()["password"]
+        self.assertEqual(old_password, new_password)
+
+        self.user_secret_dict["engine"] = (
+            self.influxdb_it_client.TIMESTREAM_INFLUXDB_ENGINE
+        )
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_password = self.user_secret_dict["password"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_password = self.aws_it_client.get_user_secret_dict()["password"]
+        self.assertEqual(old_password, new_password)
+
+        self.user_secret_dict["username"] = (
+            self.influxdb_it_client.INFLUXDB_ADMIN_USERNAME
+        )
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_password = self.user_secret_dict["password"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_password = self.aws_it_client.get_user_secret_dict()["password"]
+        self.assertEqual(old_password, new_password)
+
+        self.user_secret_dict["dbIdentifier"] = self.influxdb_it_client.influxdb_id
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_password = self.user_secret_dict["password"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), False)
+        new_password = self.aws_it_client.get_user_secret_dict()["password"]
+        self.assertEqual(old_password, new_password)
+
+        self.user_secret_dict["operatorTokenArn"] = self.aws_it_client.admin_secret_arn
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_password = self.user_secret_dict["password"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_password = self.aws_it_client.get_user_secret_dict()["password"]
+        self.assertNotEqual(old_password, new_password)
+
+    def test_operator_token_rotation(self):
+        """
+        Successful rotation for operator token with token provided.
+        """
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_user_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertNotEqual(old_token, new_user_token)
+
+    def test_retrigger_operator_token_rotation(self):
+        """
+        Successful re-rotation for operator token.
+        """
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertNotEqual(old_token, new_token)
+
+        old_token = new_token
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertNotEqual(old_token, new_token)
+
+    def test_all_access_token_rotation_no_token_create_auth_enabled(self):
+        """
+        Successful rotation for allAccess token without token provided.
+        """
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_ALL_ACCESS
+        )
+        # Set the user secret using the new all access token
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        self.aws_it_client.set_create_auth(True)
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_secret_dict = self.aws_it_client.get_user_secret_dict()
+        self.assertIn("token", new_secret_dict)
+
+        new_token = new_secret_dict["token"]
+        self.assert_token_is_scoped_to_primary_org(token=new_token)
+
+    def test_all_access_token_rotation_create_auth_disabled(self):
+        """
+        Successful rotation for allAccess token with token provided.
+        """
+        self.influxdb_it_client.create_current_auth(
+            create_all_access_token_perms(
+                org_id=self.influxdb_it_client.influxdb_org_id,
+                user_id=self.influxdb_it_client.influxdb_admin_id,
+            )
+        )
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_ALL_ACCESS,
+            token=self.influxdb_it_client.current_auth.token,
+        )
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertNotEqual(old_token, new_token)
+        self.assert_token_is_scoped_to_primary_org(token=new_token)
+
+    def test_retrigger_all_access_token_rotation_no_token_create_auth_enabled(self):
+        """
+        Successful re-rotation for allAccess token.
+        """
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_ALL_ACCESS
+        )
+        # Set the user secret using the new all access token
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        self.aws_it_client.set_create_auth(True)
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_secret_dict = self.aws_it_client.get_user_secret_dict()
+        self.assertIn("token", new_secret_dict)
+        old_token = new_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_secret_dict = self.aws_it_client.get_user_secret_dict()
+        self.assertIn("token", new_secret_dict)
+        new_token = new_secret_dict["token"]
+        self.assertNotEqual(old_token, new_token)
+
+    def test_custom_token_rotation_create_auth_enabled(self):
+        """
+        Successful rotation for custom token with token provided.
+        """
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_CUSTOM,
+            permissions=["read-orgs"],
+        )
+        self.influxdb_it_client.create_current_auth(
+            token_perms=create_custom_token_perms(
+                org_id=self.influxdb_it_client.influxdb_org_id,
+                current_secret_dict=self.user_secret_dict,
+            )
+        )
+        # Add the new custom token to the user secret dict
+        self.user_secret_dict["token"] = self.influxdb_it_client.current_auth.token
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_token = self.user_secret_dict["token"]
+
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assertNotEqual(old_token, new_token)
+        self.assert_token_is_scoped_to_primary_org(token=new_token)
+
+    def test_custom_token_rotation_no_token_create_auth_enabled(self):
+        """
+        Successful rotation for custom token without token provided.
+        """
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_CUSTOM,
+            permissions=["read-orgs"],
+        )
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        self.aws_it_client.set_create_auth(True)
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_secret_dict = self.aws_it_client.get_user_secret_dict()
+        self.assertIn("token", new_secret_dict)
+
+        new_token = new_secret_dict["token"]
+        self.assert_token_is_scoped_to_primary_org(token=new_token)
+
+    def test_retrigger_custom_token_rotation_no_token_create_auth_enabled(self):
+        """
+        Successful re-rotation for custom token.
+        """
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_CUSTOM,
+            permissions=["read-orgs"],
+        )
+        # Set the user secret using the new all access token
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        self.aws_it_client.set_create_auth(True)
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_secret_dict = self.aws_it_client.get_user_secret_dict()
+        self.assertIn("token", new_secret_dict)
+
+        new_token = new_secret_dict["token"]
+        self.assert_token_is_scoped_to_primary_org(token=new_token)
+
+        # Rotate newly-created custom token
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.set_user_secret_dict(
+            token_type=self.influxdb_it_client.TOKEN_TYPE_CUSTOM,
+            token=new_token,
+            permissions=["read-orgs"],
+        )
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+
+        new_token = self.aws_it_client.get_user_secret_dict()["token"]
+        self.assert_token_is_scoped_to_primary_org(token=new_token)
+
+    def test_username_and_password_rotation_non_existent_user_create_auth_enabled(self):
+        """
+        Successful rotation for non-existent-user with create auth enabled.
+        """
+        self.set_user_secret_dict(
+            username=self.influxdb_it_client.NON_EXISTENT_USERNAME
+        )
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        self.aws_it_client.set_create_auth(True)
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_secret_dict = self.aws_it_client.get_user_secret_dict()
+        self.assertIn("password", new_secret_dict)
+
+    def test_username_and_password_rotation(self):
+        """
+        Successful rotation for existing user with create auth disabled.
+        """
+        self.set_user_secret_dict(
+            username=self.influxdb_it_client.INFLUXDB_ADMIN_USERNAME,
+            password=self.influxdb_it_client.influxdb_admin_password,
+        )
+        self.aws_it_client.post_user_secret(secret_dict=self.user_secret_dict)
+        old_password = self.user_secret_dict["password"]
+        self.assertEqual(self.aws_it_client.rotate_user_secret(), True)
+        new_password = self.aws_it_client.get_user_secret_dict()["password"]
+        self.assertNotEqual(old_password, new_password)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="Multi-user rotation Lambda integration tests"
+    )
+    parser.add_argument(
+        "--region",
+        help="The name of the AWS region to use for integration testing. "
+        "If not provided, will default to the AWS_DEFAULT_REGION environment variable.",
+        required=False,
+    )
+    parser.add_argument(
+        "--cleanup",
+        help="Whether to teardown all testing resources, including the "
+        "Timestream for InfluxDB instance and secrets.",
+        required=False,
+        action="store_true",
+    )
+    args, unknown = parser.parse_known_args()
+    if args.region is not None:
+        aws_region_name = args.region
+        os.environ["AWS_DEFAULT_REGION"] = aws_region_name
+    else:
+        try:
+            aws_region_name = os.environ["AWS_DEFAULT_REGION"]
+        except KeyError:
+            logger.error("AWS_DEFAULT_REGION environment variable not set. Exiting.")
+            exit(1)
+    cleanup = args.cleanup
+
+    # unittest.main() also parses sys.argv and won't recognize --cleanup or --region
+    filtered_argv = []
+    for i in range(len(sys.argv)):
+        if (
+            sys.argv[i] != "--cleanup"
+            and sys.argv[i] != "--region"
+            and (i == 0 or sys.argv[i - 1] != "--region")
+        ):
+            filtered_argv.append(sys.argv[i])
+    sys.argv = filtered_argv
+    my_base = BaseTestCases()
+    unittest.main(exit=False)

--- a/SecretsManagerInfluxDBMultiUserRotation/integration/integration_test_utils.py
+++ b/SecretsManagerInfluxDBMultiUserRotation/integration/integration_test_utils.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import string
+import secrets
+import logging
+
+logger = logging.getLogger("integration_test.py")
+logger.setLevel(logging.INFO)
+log_handler = logging.StreamHandler()
+log_formatter = logging.Formatter("%(levelname)s: %(message)s")
+log_handler.setFormatter(log_formatter)
+logger.addHandler(log_handler)
+
+
+def random_string(n):
+    return "".join(
+        secrets.choice(string.ascii_letters + string.digits) for _ in range(n)
+    )

--- a/SecretsManagerInfluxDBMultiUserRotation/lambda_function.py
+++ b/SecretsManagerInfluxDBMultiUserRotation/lambda_function.py
@@ -257,7 +257,7 @@ def create_secret(secrets_client, boto_session, arn, version_id, create_auth_ena
         boto_session (session): Session to retrieve timestream-influxdb client
         arn (string): The secret ARN or other identifier
         version_id (string): The ClientRequestToken associated with the secret version
-        auth_creation_enabled (boolean): Flag for if authentication creation is enabled
+        create_auth_enabled (boolean): Flag for if authentication creation is enabled
 
     Raises:
         ResourceNotFoundException: If the secret with the specified arn and stage does not exist
@@ -912,9 +912,11 @@ def get_secret_dict(secrets_client, arn, stage, version_id=None):
     This helper function gets credentials for the arn and stage passed in and returns the dictionary by parsing the
     JSON string
 
-    Args: secrets_client (client): The secrets manager service client arn (string): The secret ARN or other
-    identifier stage (string): The stage identifying the secret version versionId (string): The ClientRequestToken
-    associated with the secret version, or None if no validation is desired
+    Args:
+        secrets_client (client): The secrets manager service client
+        arn (string): The secret ARN or other identifier
+        stage (string): The stage identifying the secret version
+        versionId (string): The ClientRequestToken associated with the secret version, or None if no validation is desired
 
     Returns:
         SecretDictionary: Secret dictionary

--- a/SecretsManagerInfluxDBMultiUserRotation/lambda_function.py
+++ b/SecretsManagerInfluxDBMultiUserRotation/lambda_function.py
@@ -1,0 +1,1045 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import boto3
+import json
+import logging
+import os
+import influxdb_client
+import re
+from contextlib import contextmanager
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+ALL_PERMISSION_TYPES = [
+    "authorizations",
+    "buckets",
+    "dashboards",
+    "orgs",
+    "sources",
+    "tasks",
+    "telegrafs",
+    "users",
+    "variables",
+    "scrapers",
+    "secrets",
+    "labels",
+    "views",
+    "documents",
+    "notificationRules",
+    "notificationEndpoints",
+    "checks",
+    "dbrp",
+    "notebooks",
+    "annotations",
+    "remotes",
+    "replications",
+]
+
+TIMESTREAM_INFLUXDB_SERVICE = "timestream-influxdb"
+
+# Mandatory user and token secret fields
+INFLUXDB_ENGINE = "engine"
+INFLUXDB_INSTANCE_IDENTIFIER = "dbIdentifier"
+INFLUXDB_OPERATOR_TOKEN_ARN = "operatorTokenArn"
+
+# Mandatory user secret fields
+INFLUXDB_USERNAME = "username"
+
+# Mandatory token secret fields
+INFLUXDB_TOKEN_TYPE = "type"
+
+# Optional user and token secret fields
+INFLUXDB_ORG = "org"
+
+# Optional user secret fields
+INFLUXDB_PASSWORD = "password"
+
+# Optional token secret fields
+INFLUXDB_TOKEN = "token"
+INFLUXDB_WRITE_BUCKET = "writeBucket"
+INFLUXDB_READ_BUCKET = "readBucket"
+INFLUXDB_PERMISSIONS = "permissions"
+
+# Stages
+CURRENT_STAGE = "AWSCURRENT"
+PENDING_STAGE = "AWSPENDING"
+
+# Steps
+CREATE_STEP = "createSecret"
+SET_STEP = "setSecret"
+TEST_STEP = "testSecret"
+FINISH_STEP = "finishSecret"
+
+# get_db_info response fields
+INFLUXDB_ENDPOINT = "endpoint"
+
+# Custom permission string indexes
+CUSTOM_PERM_STRING_ACTION_IDX = 0
+CUSTOM_PERM_STRING_TYPE_IDX = 1
+
+# Environment variable keys
+SECRETS_MANAGER_ENDPOINT = "SECRETS_MANAGER_ENDPOINT"
+AUTH_CREATION_ENABLED = "AUTHENTICATION_CREATION_ENABLED"
+
+
+def lambda_handler(event, context):
+    """Secrets Manager InfluxDB Token Rotation Handler
+
+    This handler uses the master-user rotation scheme to rotate an InfluxDB authentication token. This rotation
+    scheme authenticates the current user in the InfluxDB instance and creates a new token for the user with the same
+    permissions. The new token is then authenticated and verified to have the same properties as the previous token.
+    The old token is then deleted, and the rotation is complete. InfluxDB client does not support setting a custom
+    value for a token, so the createSecret and setSecret events both take place during the createSecret step.
+
+    Args:
+        event (dict): Lambda dictionary of event parameters. These keys must include the following:
+            - SecretId: The secret ARN or identifier
+            - ClientRequestToken: The ClientRequestToken of the secret version
+            - Step: The rotation step (one of createSecret, setSecret, testSecret, or finishSecret)
+
+        context (LambdaContext): The Lambda runtime information
+
+    Raises:
+        ResourceNotFoundException: If the secret with the specified arn and stage does not exist
+        ValueError: If the secret is not properly configured for rotation
+        KeyError: If SECRETS_MANAGER_ENDPOINT not set in the environment variables
+
+    """
+    arn = event["SecretId"]
+    version_id = event["ClientRequestToken"]
+    step = event["Step"]
+
+    if arn == "" or arn is None:
+        raise ValueError("arn is null or empty.")
+    if version_id == "" or version_id is None:
+        raise ValueError("version_id is null or empty.")
+    if step == "" or step is None:
+        raise ValueError("step is null or empty.")
+
+    boto_session = boto3.Session()
+
+    if SECRETS_MANAGER_ENDPOINT not in os.environ:
+        raise KeyError(
+            "SECRETS_MANAGER_ENDPOINT environment variable not set in the environment variables."
+        )
+
+    secret_manager_endpoint = os.environ[SECRETS_MANAGER_ENDPOINT]
+    if secret_manager_endpoint == "" or secret_manager_endpoint is None:
+        raise ValueError(
+            "Secret manager endpoint is null or empty, set the environment variable in the lambda configuration."
+        )
+    secrets_client = boto_session.client(
+        "secretsmanager", endpoint_url=secret_manager_endpoint
+    )
+
+    create_auth_enabled = False
+
+    # By default user and token creation is not enabled
+    if (
+        AUTH_CREATION_ENABLED in os.environ
+        and os.environ[AUTH_CREATION_ENABLED] == "true"
+    ):
+        create_auth_enabled = True
+
+    # Make sure the version is staged correctly
+    metadata = secrets_client.describe_secret(SecretId=arn)
+    if not metadata["RotationEnabled"]:
+        logger.error("Secret %s is not enabled for rotation" % arn)
+        raise ValueError("Secret %s is not enabled for rotation" % arn)
+    versions = metadata["VersionIdsToStages"]
+    if version_id not in versions:
+        logger.error(
+            "Secret version %s has no stage for rotation of secret %s."
+            % (version_id, arn)
+        )
+        raise ValueError(
+            "Secret version %s has no stage for rotation of secret %s."
+            % (version_id, arn)
+        )
+    if CURRENT_STAGE in versions[version_id]:
+        logger.info(
+            "Secret version %s already set as AWSCURRENT for secret %s."
+            % (version_id, arn)
+        )
+        return
+    elif PENDING_STAGE not in versions[version_id]:
+        logger.error(
+            "Secret version %s not set as AWSPENDING for rotation of secret %s."
+            % (version_id, arn)
+        )
+        raise ValueError(
+            "Secret version %s not set as AWSPENDING for rotation of secret %s."
+            % (version_id, arn)
+        )
+
+    if step == CREATE_STEP:
+        create_secret(
+            secrets_client, boto_session, arn, version_id, create_auth_enabled
+        )
+
+    elif step == SET_STEP:
+        logger.info(
+            "set_secret has no function as we use the value from the already created token in the create_secret stage"
+        )
+
+    elif step == TEST_STEP:
+        test_secret(secrets_client, boto_session, arn, version_id)
+
+    elif step == FINISH_STEP:
+        finish_secret(secrets_client, boto_session, arn, version_id)
+
+    else:
+        raise ValueError("Invalid step parameter %s" % step)
+
+
+@contextmanager
+def get_connection(endpoint_url, secret_dict, arn, step):
+    """Get connection to InfluxDB
+
+    This helper function returns a connection to the provided InfluxDB instance.
+
+    Args:
+        endpoint_url (string): Url for the InfluxDB instance
+        secret_dict (dictionary): Dictionary with either username/password or token to authenticate connection
+        arn (string): Arn for secret to log in event of failure to make connection
+        step (string): Step in which the lambda function is making the connection
+
+    Raises:
+        ValueError: If the connection or health check fails
+
+    """
+    conn = None
+    try:
+        conn = (
+            influxdb_client.InfluxDBClient(
+                url="https://" + endpoint_url + ":8086",
+                token=secret_dict[INFLUXDB_TOKEN],
+                debug=False,
+                verify_ssl=True,
+            )
+            if INFLUXDB_TOKEN in secret_dict
+            else influxdb_client.InfluxDBClient(
+                url="https://" + endpoint_url + ":8086",
+                username=secret_dict[INFLUXDB_USERNAME],
+                password=secret_dict[INFLUXDB_PASSWORD],
+                debug=False,
+                verify_ssl=True,
+            )
+        )
+
+        # Verify InfluxDB connection
+        health = conn.ping()
+        if not health:
+            logger.error("%s: Connection failure" % step)
+
+        yield conn
+    except Exception as err:
+        raise ValueError(
+            "%s: Failed to set new authorization with secret ARN %s %s"
+            % (step, arn, err)
+        ) from err
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def create_secret(secrets_client, boto_session, arn, version_id, create_auth_enabled):
+    """Create the secret
+
+    This method first checks for the existence of a secret for the passed in token or user. If one does not exist,
+    it will generate a new token or user in the InfluxDB instance if authentication creation is enabled, and put the new
+    value in the AWSPENDING secret value. This function completes both the createSecret and setSecret steps.
+
+    Args:
+        secrets_client (client): The secrets manager service client
+        boto_session (session): Session to retrieve timestream-influxdb client
+        arn (string): The secret ARN or other identifier
+        version_id (string): The ClientRequestToken associated with the secret version
+        auth_creation_enabled (boolean): Flag for if authentication creation is enabled
+
+    Raises:
+        ResourceNotFoundException: If the secret with the specified arn and stage does not exist
+        ValueError: If the secrets manager token fails to create a new token
+
+    """
+
+    # Make sure the current secret exists
+    current_secret_dict = get_secret_dict(secrets_client, arn, CURRENT_STAGE)
+
+    # Now try to get the secret token, if that fails, put a new secret
+    try:
+        get_secret_dict(secrets_client, arn, PENDING_STAGE, version_id)
+        logger.info("create_secret: Successfully retrieved secret for %s." % arn)
+    except secrets_client.exceptions.ResourceNotFoundException:
+        operator_secret_dict = get_operator_dict(
+            secrets_client, current_secret_dict, CURRENT_STAGE, arn
+        )
+        with get_connection(
+            get_db_info(
+                current_secret_dict[INFLUXDB_INSTANCE_IDENTIFIER], boto_session
+            ),
+            operator_secret_dict,
+            arn,
+            CREATE_STEP,
+        ) as conn:
+            if INFLUXDB_TOKEN_TYPE in current_secret_dict:
+                if (
+                    INFLUXDB_TOKEN not in current_secret_dict
+                    and not create_auth_enabled
+                ):
+                    raise ValueError(
+                        "Authentication creation has not been enabled to allow the lambda function to create tokens"
+                    )
+
+                org = next(
+                    (
+                        org
+                        for org in conn.organizations_api().find_organizations()
+                        if org.name == current_secret_dict[INFLUXDB_ORG]
+                    ),
+                    None,
+                )
+                if org is None:
+                    raise ValueError("Org does not exist to associate token value with")
+
+                if current_secret_dict[INFLUXDB_TOKEN_TYPE] == "operator":
+                    token_perms = create_operator_token_perms()
+                elif current_secret_dict[INFLUXDB_TOKEN_TYPE] == "allAccess":
+                    token_perms = create_all_access_token_perms(
+                        org.id, conn.users_api().me().id
+                    )
+                else:  # custom
+                    token_perms = create_custom_token_perms(current_secret_dict, org.id)
+
+                if len(token_perms) == 0:
+                    raise ValueError("No permissions were set for token creation")
+
+                final_token_perm = validate_current_token(
+                    conn, current_secret_dict, token_perms
+                )
+                create_token(conn, current_secret_dict, final_token_perm, org)
+            else:
+                update_user_creds(
+                    secrets_client,
+                    boto_session,
+                    arn,
+                    conn,
+                    current_secret_dict,
+                    create_auth_enabled,
+                )
+
+            secrets_client.put_secret_value(
+                SecretId=arn,
+                ClientRequestToken=version_id,
+                SecretString=json.dumps(current_secret_dict),
+                VersionStages=[PENDING_STAGE],
+            )
+
+    logger.info(
+        "create_secret: Successfully created new authorization for ARN %s and version %s."
+        % (arn, version_id)
+    )
+
+
+def update_user_creds(
+    secrets_client, boto_session, arn, conn, current_secret_dict, create_auth_enabled
+):
+    """Update credentials for user
+
+    Set the new user credentials in the InfluxDB instance. If user is not already created in the DB instance,
+    create a new user if user creation is enabled. A password must be provided in the secret to authenticate
+    an already existing user.
+
+    Args:
+        secrets_client (client): The secrets manager service client
+        boto_session (session): Session to retrieve timestream-influxdb client
+        arn (string): The secret ARN or other identifier
+        conn (InfluxDBClient): Connection to InfluxDB instance
+        current_secret_dict (dictionary): Dictionary with the user and password being set
+        create_auth_enabled (boolean): Flag for if user creation is enabled
+
+    """
+
+    users = conn.users_api().find_users()
+    # Search through users for one that matches the current user
+    user = next(
+        (
+            user
+            for user in users.users
+            if user.name == current_secret_dict[INFLUXDB_USERNAME]
+        ),
+        None,
+    )
+    new_password = secrets_client.get_random_password()["RandomPassword"]
+
+    if user is not None and INFLUXDB_PASSWORD not in current_secret_dict:
+        raise ValueError(
+            "User %s password has not been set yet, set the password before performing a rotation."
+            % current_secret_dict[INFLUXDB_USERNAME]
+        )
+
+    if user is not None and INFLUXDB_PASSWORD in current_secret_dict:
+        with get_connection(
+            get_db_info(
+                current_secret_dict[INFLUXDB_INSTANCE_IDENTIFIER], boto_session
+            ),
+            current_secret_dict,
+            arn,
+            CREATE_STEP,
+        ) as test_user_client:
+            # Ensure user defined in secret can authenticate
+            test_user_client.users_api().me()
+
+    if user is None:
+        if not create_auth_enabled:
+            raise ValueError(
+                "Authentication creation has not been enabled to allow the lambda function to create users"
+            )
+
+        logger.info(
+            "User has not been created yet, creating new user %s"
+            % current_secret_dict[INFLUXDB_USERNAME]
+        )
+        user = conn.users_api().create_user(current_secret_dict[INFLUXDB_USERNAME])
+
+        # If org is supplied in dictionary, add user to the organization
+        if INFLUXDB_ORG in current_secret_dict:
+            org = next(
+                (
+                    org
+                    for org in conn.organizations_api().find_organizations()
+                    if org.name == current_secret_dict[INFLUXDB_ORG]
+                ),
+                None,
+            )
+            if org is None:
+                raise ValueError("Org does not exist in DB instance")
+            conn.organizations_api()._organizations_service.post_orgs_id_members(
+                org.id, user
+            )
+
+    conn.users_api().update_password(user=user.id, password=new_password)
+    current_secret_dict[INFLUXDB_PASSWORD] = new_password
+
+
+def append_organization_scoped_permission(token_perms, perm_type, action, org_id):
+    """
+
+    Append permissions to the permission list with the format: "<action>:orgs/<org_id>/<perm_type>"
+
+    Args:
+        token_perms (list): List appending the permission to
+        perm_type (string): The type value for the permission
+        action (string): The action value for the permission
+        org_id (string): The organization id
+
+    """
+    token_perms.append(
+        influxdb_client.Permission(
+            resource=influxdb_client.PermissionResource(type=perm_type, org_id=org_id),
+            action=action,
+        )
+    )
+
+
+def append_organization_permission(token_perms, perm_type, action, org_id):
+    """
+
+    Append permissions to the permission list with the format: "<action>:/orgs/org_id"
+
+    Args:
+        token_perms (list): List appending the permission to
+        perm_type (string): The type value for the permission
+        action (string): The action value for the permission
+        org_id (string): The organization id
+
+    """
+    token_perms.append(
+        influxdb_client.Permission(
+            resource=influxdb_client.PermissionResource(id=org_id, type=perm_type),
+            action=action,
+        )
+    )
+
+
+def append_user_permission(token_perms, perm_type, action, user_id):
+    """
+
+    Append permissions to the permission list with the format: "<action>:/users/<user_id>"
+
+    Args:
+        token_perms (list): List appending the permission to
+        perm_type (string): The type value for the permission
+        action (string): The action value for the permission
+        user_id (string): The user id
+
+    """
+    token_perms.append(
+        influxdb_client.Permission(
+            resource=influxdb_client.PermissionResource(id=user_id, type=perm_type),
+            action=action,
+        )
+    )
+
+
+def append_organization_and_bucket_scoped_permission(
+    token_perms, perm_type, action, org_id, bucket_id
+):
+    """
+
+    Append permissions to the permission list with the format: "<action>:orgs/<org_id>/buckets/<bucket_id>"
+
+    Args:
+        token_perms (list): List appending the permission to
+        perm_type (string): The type value for the permission
+        action (string): The action value for the permission
+        org_id (string): The organization id
+        bucket_id (string): The bucket id
+
+    """
+    token_perms.append(
+        influxdb_client.Permission(
+            resource=influxdb_client.PermissionResource(
+                name=bucket_id, type=perm_type, org_id=org_id
+            ),
+            action=action,
+        )
+    )
+
+
+def append_non_scoped_permission(token_perms, perm_type, action):
+    """
+
+    Append permissions to the permission list with the format: "<action>:/<perm_type>"
+
+    Args:
+        token_perms (list): List appending the permission to
+        perm_type (string): The type value for the permission
+        action (string): The action value for the permission
+
+    """
+    token_perms.append(
+        influxdb_client.Permission(
+            resource=influxdb_client.PermissionResource(type=perm_type), action=action
+        )
+    )
+
+
+def validate_current_token(conn, current_secret_dict, token_perms):
+    """
+
+    Validates that the permission set for the token type line up with those defined by the current token.
+
+    Args:
+        conn (InfluxDBClient): The connection to the InfluxDB instance
+        current_secret_dict (dictionary): Secret dictionary with token type and permissions
+        token_perms (list): All permissions that should be set for new token
+
+    Raises:
+        ValueError: If token type and permissions are not set appropriately
+
+    Returns
+        final_token_perms (list): All permissions that should be set
+    """
+
+    # Ensure no operator tokens can be created without an already existing token
+    if (
+        INFLUXDB_TOKEN_TYPE in current_secret_dict
+        and current_secret_dict[INFLUXDB_TOKEN_TYPE] == "operator"
+        and INFLUXDB_TOKEN not in current_secret_dict
+    ):
+        raise ValueError(
+            "Operator tokens cannot be created without an already existing operator token"
+        )
+
+    # If no value is set for the token, and the token is not of type operator we will create the new token
+    if (
+        INFLUXDB_TOKEN_TYPE in current_secret_dict
+        and INFLUXDB_TOKEN not in current_secret_dict
+    ):
+        return token_perms
+
+    # Ensure the already created token is the permission set that we use when creating the new token
+    if (
+        INFLUXDB_TOKEN_TYPE in current_secret_dict
+        and INFLUXDB_TOKEN in current_secret_dict
+    ):
+        authorizations = conn.authorizations_api().find_authorizations()
+        current_auth = next(
+            (
+                auth
+                for auth in authorizations
+                if auth.token == current_secret_dict[INFLUXDB_TOKEN]
+            ),
+            None,
+        )
+        if current_auth is None:
+            raise ValueError(
+                "InfluxDB token is incorrect (can't find matching token) or empty operator token is "
+                "set"
+            )
+        else:
+            logger.info(
+                "Existing token found in DB instance, token will be rotated with existing permissions"
+            )
+            return current_auth.permissions
+    else:
+        raise ValueError(
+            "InfluxDB token or token type is sent incorrectly, ensure type and value are defined in "
+            "Secret Manager"
+        )
+
+
+def create_token(conn, current_secret_dict, token_perms, org):
+    """
+
+    Create new authorization token in InfluxDB instance. The type and permissions are set from the values
+    defined in the secret dictionary. If these values have been altered then the new auth token will not be created.
+
+    Args:
+        conn (InfluxDBClient): The connection to the InfluxDB instance
+        current_secret_dict (dictionary): Secret dictionary with token type and permissions
+        token_perms (list): Set of permissions to apply to the token being created
+        org (Organization): The organization to associate with the token
+
+    """
+
+    # Influxdb doesn't support setting token values for already created tokens
+    # We must therefore create the token in InfluxDB at this stage
+    new_authorization = conn.authorizations_api().create_authorization(
+        org_id=org.id, permissions=token_perms
+    )
+    current_secret_dict[INFLUXDB_TOKEN] = new_authorization.token
+
+
+def create_operator_token_perms():
+    """
+
+    Create the set of permissions defined for an operator token.
+
+    """
+    token_perms = []
+    for perm_type in ALL_PERMISSION_TYPES:
+        append_non_scoped_permission(token_perms, perm_type, "read")
+        append_non_scoped_permission(token_perms, perm_type, "write")
+
+    return token_perms
+
+
+def create_all_access_token_perms(org_id, user_id):
+    """
+
+    Create the set of permissions defined for an allAccess token.
+
+    Args:
+        org_id (string): Id for the organization to set permissions
+        user_id (string): The id for the user
+
+    """
+    token_perms = []
+    # allAccess token is scoped to a specific org and can access all buckets in that organization
+    for perm_type in ALL_PERMISSION_TYPES:
+        if perm_type == "users":
+            append_user_permission(token_perms, perm_type, "read", user_id)
+            append_user_permission(token_perms, perm_type, "write", user_id)
+        elif perm_type == "orgs":
+            # all access tokens only get read access for the organization
+            append_organization_permission(token_perms, perm_type, "read", org_id)
+        else:
+            append_organization_scoped_permission(
+                token_perms, perm_type, "read", org_id
+            )
+            append_organization_scoped_permission(
+                token_perms, perm_type, "write", org_id
+            )
+
+    return token_perms
+
+
+def create_custom_token_perms(current_secret_dict, org_id):
+    """
+
+    Create the set of permissions defined by the custom permissions set in the secret.
+
+    Args:
+        current_secret_dict (dictionary): Set of permissions to set for token
+        org_id (string): Id for the organization to set permissions
+
+    """
+    token_perms = []
+
+    if INFLUXDB_READ_BUCKET in current_secret_dict:
+        for bucket_id in current_secret_dict[INFLUXDB_READ_BUCKET]:
+            append_organization_and_bucket_scoped_permission(
+                token_perms, "buckets", "read", org_id, bucket_id
+            )
+    if INFLUXDB_WRITE_BUCKET in current_secret_dict:
+        for bucket_id in current_secret_dict[INFLUXDB_WRITE_BUCKET]:
+            append_organization_and_bucket_scoped_permission(
+                token_perms, "buckets", "write", org_id, bucket_id
+            )
+    # Handle permissions list, i.e. ["write-tasks", "read-tasks"]
+    if INFLUXDB_PERMISSIONS in current_secret_dict:
+        for perm in current_secret_dict[INFLUXDB_PERMISSIONS]:
+            perm_type = get_type_from_perm_string(perm)
+            action = get_action_from_perm_string(perm)
+            # A permission of the form "read-orgs" needs to be formatted as
+            # "read:/orgs/<org ID>", meaning the permission is to read the organization.
+            # append_organization_permission will format permissions this way
+            if perm_type == "orgs":
+                append_organization_permission(token_perms, perm_type, action, org_id)
+            else:
+                append_organization_scoped_permission(
+                    token_perms,
+                    perm_type,
+                    action,
+                    org_id,
+                )
+
+    return token_perms
+
+
+def get_action_from_perm_string(perm_string):
+    """
+
+    Parse string to return the action portion, i.e., <action>-<type>
+
+    Args:
+        perm_string (string): The permission string
+
+    """
+
+    return get_perm_string_item(perm_string, CUSTOM_PERM_STRING_ACTION_IDX)
+
+
+def get_type_from_perm_string(perm_string):
+    """
+
+    Parse string to return the type portion, i.e., <action>-<type>
+
+    Args:
+        perm_string (string): The permission string
+
+    """
+
+    return get_perm_string_item(perm_string, CUSTOM_PERM_STRING_TYPE_IDX)
+
+
+def get_perm_string_item(perm_string, idx):
+    """
+
+    Parse string to return either the action or type portion, i.e., <action>-<type>
+
+    Args:
+        perm_string: The permission string
+        idx: The index of the item to retrieve
+
+    Raises:
+        ValueError: If permission string does not match the formation <action>-<type>
+
+    """
+
+    if not re.search("^[a-z][a-z]+-[a-z]+[a-z]$", perm_string):
+        raise ValueError(
+            "Permission %s does not fit the format <action>-<type>, e.g., write-tasks"
+        )
+
+    return perm_string.split("-", 1)[idx]
+
+
+def test_secret(secrets_client, boto_session, arn, version_id):
+    """Test the token against the InfluxDB instance
+
+    This method authenticates the tokens in the AWSCURRENT and AWSPENDING stages against the InfluxDB instance. Once
+    both tokens have been authenticated, the users the tokens belong to is verified to be the same,
+    and the authentication tokens are verified to have the same permission values.
+
+    Args:
+        secrets_client (client): The secrets manager service client
+        boto_session (session): Session to retrieve timestream-influxdb client
+        arn (string): The secret ARN or other identifier
+        version_id (string): The ClientRequestToken associated with the secret version
+
+    Raises: ValueError: If the secrets manager or pending user tokens fail to authenticate, or the current and
+    pending token permissions or users are not identical.
+
+    """
+
+    current_secret_dict = get_secret_dict(secrets_client, arn, CURRENT_STAGE)
+    pending_secret_dict = get_secret_dict(
+        secrets_client, arn, PENDING_STAGE, version_id
+    )
+    operator_secret_dict = get_operator_dict(
+        secrets_client, pending_secret_dict, CURRENT_STAGE, arn
+    )
+
+    # Verify pending authentication can successfully authenticate
+    with get_connection(
+        get_db_info(pending_secret_dict[INFLUXDB_INSTANCE_IDENTIFIER], boto_session),
+        pending_secret_dict,
+        arn,
+        TEST_STEP,
+    ) as pending_user_client:
+        pending_user_client.organizations_api().find_organizations()
+
+    with get_connection(
+        get_db_info(current_secret_dict[INFLUXDB_INSTANCE_IDENTIFIER], boto_session),
+        operator_secret_dict,
+        arn,
+        CREATE_STEP,
+    ) as operator_client:
+        if (
+            INFLUXDB_TOKEN in pending_secret_dict
+            and INFLUXDB_TOKEN in current_secret_dict
+        ):
+            authorizations = operator_client.authorizations_api().find_authorizations()
+            current_auth = next(
+                (
+                    auth
+                    for auth in authorizations
+                    if auth.token == current_secret_dict[INFLUXDB_TOKEN]
+                ),
+                None,
+            )
+            pending_auth = next(
+                (
+                    auth
+                    for auth in authorizations
+                    if auth.token == pending_secret_dict[INFLUXDB_TOKEN]
+                )
+            )
+
+            # Validate current and pending authorizations have the same permissions if there was a previously set
+            # auth token
+            if current_auth is not None and (
+                not current_auth.permissions == pending_auth.permissions
+            ):
+                raise ValueError(
+                    "Current and pending tokens failed permissions test for secret ARN %s"
+                    % arn
+                )
+
+            # Validate current and pending tokens have the same users
+            if current_auth is not None and (
+                not current_auth.user == pending_auth.user
+            ):
+                raise ValueError(
+                    "Current and pending tokens failed user equality test for secret ARN %s"
+                    % arn
+                )
+
+    logger.info("test_secret: Successfully tested authentication rotation")
+
+
+def finish_secret(secrets_client, boto_session, arn, version_id):
+    """Finish the secret
+
+    This method finalizes the rotation process by marking the secret version passed in as the AWSCURRENT secret and
+    deleting the previous user authentication token in the InfluxDB instance.
+
+    Args:
+        secrets_client (client): The secrets manager service client
+        boto_session (session): Session to retrieve timestream-influxdb client
+        arn (string): The secret ARN or other identifier
+        version_id (string): The ClientRequestToken associated with the secret version
+
+    Raises:
+        ValueError: If the secrets manager fails to delete the previous user token in the InfluxDB instance.
+
+    """
+    current_secret_dict = get_secret_dict(secrets_client, arn, CURRENT_STAGE)
+    pending_secret_dict = get_secret_dict(
+        secrets_client, arn, PENDING_STAGE, version_id
+    )
+    operator_secret_dict = get_operator_dict(
+        secrets_client, pending_secret_dict, CURRENT_STAGE, arn
+    )
+
+    # First describe the secret to get the current version
+    metadata = secrets_client.describe_secret(SecretId=arn)
+    current_version = None
+    for version in metadata["VersionIdsToStages"]:
+        if CURRENT_STAGE in metadata["VersionIdsToStages"][version]:
+            if version == version_id:
+                # The correct version is already marked as current, return
+                logger.info(
+                    "finish_secret: Version %s already marked as AWSCURRENT for %s"
+                    % (version, arn)
+                )
+                return
+            current_version = version
+            break
+
+    # Finalize by staging the secret version current
+    secrets_client.update_secret_version_stage(
+        SecretId=arn,
+        VersionStage=CURRENT_STAGE,
+        MoveToVersionId=version_id,
+        RemoveFromVersionId=current_version,
+    )
+
+    # Delete previous authorization for user if using token authentication
+    if INFLUXDB_TOKEN in pending_secret_dict and INFLUXDB_TOKEN in current_secret_dict:
+        with get_connection(
+            get_db_info(
+                current_secret_dict[INFLUXDB_INSTANCE_IDENTIFIER], boto_session
+            ),
+            operator_secret_dict,
+            arn,
+            CREATE_STEP,
+        ) as operator_client:
+            authorizations = operator_client.authorizations_api().find_authorizations()
+            current_auth = next(
+                (
+                    auth
+                    for auth in authorizations
+                    if auth.token == current_secret_dict[INFLUXDB_TOKEN]
+                )
+            )
+            operator_client.authorizations_api().delete_authorization(current_auth)
+
+    logger.info(
+        "finish_secret: Successfully set AWSCURRENT stage to version %s for secret %s."
+        % (version_id, arn)
+    )
+
+
+def get_secret_dict(secrets_client, arn, stage, version_id=None):
+    """Gets the secret dictionary corresponding for the secret arn, stage, and token
+
+    This helper function gets credentials for the arn and stage passed in and returns the dictionary by parsing the
+    JSON string
+
+    Args: secrets_client (client): The secrets manager service client arn (string): The secret ARN or other
+    identifier stage (string): The stage identifying the secret version versionId (string): The ClientRequestToken
+    associated with the secret version, or None if no validation is desired
+
+    Returns:
+        SecretDictionary: Secret dictionary
+
+    Raises:
+        ResourceNotFoundException: If the secret with the specified arn and stage does not exist
+        ValueError: If the secret is not valid JSON
+        KeyError: If required keys missing in secret or engine is not 'timestream-influxdb'
+
+    """
+
+    # Only do VersionId validation against the stage if a token is passed in
+    if version_id:
+        secret = secrets_client.get_secret_value(
+            SecretId=arn, VersionId=version_id, VersionStage=stage
+        )
+    else:
+        secret = secrets_client.get_secret_value(SecretId=arn, VersionStage=stage)
+    plaintext = secret["SecretString"]
+    try:
+        secret_dict = json.loads(plaintext)
+    except Exception:
+        # wrapping json parser exceptions to avoid possible token disclosure
+        logger.error("Invalid secret value json for secret %s." % arn)
+        raise ValueError("Invalid secret value json for secret %s." % arn)
+
+    # Run semantic validations for secrets
+    if INFLUXDB_TOKEN_TYPE in secret_dict:
+        required_fields = [
+            INFLUXDB_ENGINE,
+            INFLUXDB_TOKEN_TYPE,
+            INFLUXDB_INSTANCE_IDENTIFIER,
+            INFLUXDB_OPERATOR_TOKEN_ARN,
+        ]
+    else:
+        required_fields = [
+            INFLUXDB_ENGINE,
+            INFLUXDB_USERNAME,
+            INFLUXDB_INSTANCE_IDENTIFIER,
+            INFLUXDB_OPERATOR_TOKEN_ARN,
+        ]
+
+    for field in required_fields:
+        if field not in secret_dict:
+            raise KeyError("%s key is missing from secret JSON" % field)
+
+    if INFLUXDB_TOKEN_TYPE in secret_dict and INFLUXDB_ORG not in secret_dict:
+        raise KeyError("Must set organization for token authentication")
+
+    if (
+        INFLUXDB_TOKEN_TYPE in secret_dict
+        and secret_dict[INFLUXDB_TOKEN_TYPE] == "operator"
+        and INFLUXDB_TOKEN not in secret_dict
+    ):
+        raise KeyError("The token value must be set when rotating an operator token")
+
+    if secret_dict["engine"] != TIMESTREAM_INFLUXDB_SERVICE:
+        raise KeyError(
+            "Database engine must be set to 'timestream-influxdb' in order to use this rotation lambda"
+        )
+
+    return secret_dict
+
+
+def get_operator_dict(secrets_client, secret_dict, stage, arn):
+    """Gets the secret dictionary for the operator authentication
+
+    This helper function gets credentials for the operator
+
+    Args:
+        secrets_client (client): The secrets manager service client
+        secret_dict (dict): The secret dictionary containing the ARN for the operator secret
+        stage (string): The stage identifying the secret version
+        arn (string): The secret ARN or other identifier
+
+    Returns:
+        OperatorDictionary: Operator dictionary
+
+    Raises:
+        ResourceNotFoundException: If the secret with the specified arn and stage does not exist
+        ValueError: If the secret is not valid JSON
+
+    """
+
+    required_fields = [INFLUXDB_USERNAME, INFLUXDB_PASSWORD]
+
+    operator_secret = secrets_client.get_secret_value(
+        SecretId=secret_dict[INFLUXDB_OPERATOR_TOKEN_ARN], VersionStage=stage
+    )
+    operator_plaintext = operator_secret["SecretString"]
+    try:
+        operator_secret_dict = json.loads(operator_plaintext)
+    except Exception:
+        # wrapping json parser exceptions to avoid possible token disclosure
+        logger.error("Invalid secret value json for secret %s." % arn)
+        raise ValueError("Invalid secret value json for secret %s." % arn)
+
+    # Run validations against the secret
+    for field in required_fields:
+        if field not in operator_secret_dict:
+            raise KeyError("%s key is missing from secret JSON" % field)
+
+    return operator_secret_dict
+
+
+def get_db_info(db_instance_identifier, boto_session):
+    """Get InfluxDB information
+
+    This helper function returns the url for the InfluxDB instance that matches the identifier
+    that is provided in the user secret.
+
+    Args:
+        db_instance_identifier (string): The InfluxDB instance identifier
+        boto_session (session): Session to retrieve timestream-influxdb client
+
+    Raises:
+        ValueError: Failed to retrieve DB information
+        KeyError: DB info returned does not contain expected key
+
+    """
+
+    influx_client = boto_session.client(TIMESTREAM_INFLUXDB_SERVICE)
+    describe_response = influx_client.get_db_instance(identifier=db_instance_identifier)
+
+    if describe_response is None or describe_response[INFLUXDB_ENDPOINT] is None:
+        raise KeyError("Invalid endpoint info for influxdb instance")
+
+    return describe_response[INFLUXDB_ENDPOINT]

--- a/SecretsManagerInfluxDBMultiUserRotation/requirements.txt
+++ b/SecretsManagerInfluxDBMultiUserRotation/requirements.txt
@@ -1,0 +1,2 @@
+influxdb-client[ciso]
+boto3

--- a/SecretsManagerInfluxDBSingleUserRotation/README.md
+++ b/SecretsManagerInfluxDBSingleUserRotation/README.md
@@ -1,0 +1,328 @@
+# Amazon InfluxDB Single User Rotator
+
+## Getting Started
+The InfluxDB Single-User Rotator rotates a user's authorization token or credentials using the AWS Secrets Manager. The Single-user rotator operates by using the users authentication token or credentials to rotate their token or credentials with new permission identical equivalents. The user token performing the rotation must have the permissions to perform the rotation. For token rotation the type of the token could be an `operator` or `allAccess` token to successfully complete rotation.
+
+### InfluxDB Single-user Token Rotation State Diagram
+The InfluxDB Single-user Token Rotation State Diagram illustrates how a secret authenticates the rotation of their own user or token with each successful step provided by the `Secrets Manager`.
+
+```mermaid
+stateDiagram-v2
+direction LR
+    createSecret --> testSecret: Success
+    testSecret --> finishSecret: Success
+
+    state "Step: createSecret" as createSecret
+    state createSecret {
+        Secretsmanager1: Secrets Manager
+        state1token: old token
+        state1oldtoken: old token
+        state1newtoken: new token
+
+        Secretsmanager1 --> State1UserRef1 : step - createSecret
+        State1UserRef1 --> State1UserRef2 : Creates new user token
+
+        state "User" as State1UserRef1 {
+            state1token
+        }
+        state "User" as State1UserRef2 {
+            state1oldtoken
+            state1newtoken
+        }
+    }
+
+    state "Step: testSecret" as testSecret
+    state testSecret {
+        Secretsmanager2: Secrets Manager
+        state2token: old token
+        state2oldtoken: old token
+        state2newtoken1: new token
+        state2newtoken2: new token
+
+        Secretsmanager2 --> State2UserRef1 : step - testSecret
+        State2UserRef1 --> User2 : Validates new vs old token permissions
+
+        state "User" as State2UserRef1 {
+            state2token
+            state2newtoken1
+        }
+        state "User" as User2 {
+            state2oldtoken
+            state2newtoken2
+        }
+    }
+
+    state "Step: finishSecret" as finishSecret
+    state finishSecret {
+        Secretsmanager3: Secrets Manager
+        state3token: old token
+        state3newtoken1: new token
+        state3newtoken2: new token
+
+        Secretsmanager3 --> State3UserRef1 : step - finishSecret
+        State3UserRef1 --> User3 : Deletes old token
+
+        state "User" as State3UserRef1 {
+            state3token
+            state3newtoken1
+        }
+        state "User" as User3 {
+            state3newtoken2
+        }
+    }
+
+    classDef green fill:#32cd32
+    classDef orange fill:#f96
+    classDef yellow fill:#eeff1b
+    class state1newtoken orange
+    class state2newtoken2, state2oldtoken yellow
+    class state3newtoken2 green
+
+
+```
+
+## Permissions
+The `InfluxDB Single-user Rotation Lambda` rotates an existing user or token with the same permissions that are defined for the user or token in the DB instance. This is to avoid any scenarios where privilege escalation could occur during the rotation.
+
+## Create Secret
+1. Open the AWS console
+- Navigate to `Secrets Manager`
+- Click `Store a new secret`
+- Select `Other type of secret`
+- Click on `Plaintext` under `Key/value pairs`
+- Fill in one of the following options in the text box:
+
+Token Credentials (for rotating operator token)
+```
+{
+    "engine": "timestream-influxdb",            // mandatory engine name
+    "org": "string",                            // mandatory organization to associate token with
+    "dbIdentifier": "string",                   // mandatory DB instance identifier
+    "token": "string"                           // mandatory token value
+}
+```
+
+Username and Password Credentials (for rotating admin user password)
+```
+{
+    "engine": "timestream-influxdb",            // mandatory engine name
+    "dbIdentifier": "string",                   // mandatory DB instance identifier
+    "username": "string",                       // mandatory username for rotating user
+    "password": "string"                        // mandatory current password for rotating user
+}
+```
+- Click `Next`
+- Enter a name for the secret of your choosing
+- Click `Next`
+- Click `Next` again as we will configure the rotation after we deploy the lambda
+- Click `Store`
+
+## Deploy Lambda
+1. Execute script with the following command (Requires pip3 installed)
+- If you are using MacOS or Linux, execute the following commands
+  - `./build_deployment.sh`_(to build deployable lambda function package from the source code)_
+  - Execute the following command to add execution permissions to your deployment package
+  - `sudo chmod +x influxdb-token-rotation-lambda.zip`
+- If you are using Windows, execute the following command
+  - `./build_deployment.ps1`_(to build deployable lambda function package from the source code)_
+
+2. Open the AWS console
+- Navigate to `Lambda`
+- Click `Create function`
+- Enter a function name of your choosing
+- Select `Python 3.12` for the Runtime
+- Click `Create function`
+
+3. Upload the deployment package
+- Click on `Upload from` and select `.zip` file
+- Click `Upload` and select the `influxdb-token-rotation-lambda.zip` deployment package
+- Click `Save`
+
+4. Configure environment variables for the lambda function
+- Click on `Configuration`
+- Click on `Environment Variables` and click on `Edit`
+- Click on `Add environment variable`
+- Enter `SECRETS_MANAGER_ENDPOINT` for the key value
+- Enter `https://secretsmanager.<region>.amazonaws.com` and replace `<region>` appropriately (Must be same as `Secrets Manager`)
+- Click `Save`
+
+5. Configure lambda role
+- Click on `Permissions`
+- Under `Execution role` click on the link to the lambda role
+- Under `Permissions policies` click `Add permissions` and `Create inline policy`
+- Click on `JSON` and replace the json in the text editor with the following:
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:PutSecretValue",
+                "secretsmanager:UpdateSecretVersionStage"
+            ],
+            "Resource": "<user_secret_arn>"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetRandomPassword"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "timestream-influxdb:GetDbInstance"
+            ],
+            "Resource": "arn:aws:timestream-influxdb:<region>:<account_id>:db-instance/<db_instance_id>",
+            "Effect": "Allow"
+        }
+    ]
+}
+```
+- Replace `<region>`, `<account_id>`, `<db_instance_id>`, and `<user_secret_arn>` appropriately
+- Click `Next`
+- Enter a `Policy name` of your choosing and click `Create policy`
+
+6. Configure invoke lambda permissions for the lambda function
+- Navigate back to the lambda function `Permissions` section
+- Under `Resource-based policy statements` click `Add permissions`
+- Click on `AWS service`
+- Select `Secrets Manager` under `Service`
+- Enter a `Statement ID` of your choosing
+- Select `Lambda:InvokeFunction` under `Action`
+- Click `Save`
+
+7. Configure lambda function timeout
+- Navigate to the lambda function `General configuration` section
+- Under `General configuration` click `Edit`
+- Set the `Timeout` value to 1 minute
+- Click `Save`
+
+## Configure Token Rotation
+1. Open the AWS console
+- Navigate to `Secrets Manager`
+- Select the secret that was previously created
+- Click `Rotation` and then `Edit rotation`
+- Click on `Automatic rotation`
+- Fill in the rotation schedule of your choosing
+- Under `Rotation function` select the lambda function we previously deployed
+- Ensure the checkbox to rotate immediately when stored is selected
+- Click `Save`
+
+## Verify
+1. In the secret that we created navigate to the `Overview` section
+- Click `Retrieve secret value`
+- If everything went correctly you should see a new token value under `influxdb-user-token`
+- If the value for `influxdb-user-token` has not changed, see section [Viewing CloudWatch Logs](#viewing-cloudwatch-logs) for troubleshooting
+
+## Viewing CloudWatch Logs
+1. Navigate to `Lambda`
+- Click on the function created for rotating your `InfluxDB` token
+- Click on `Monitor`
+- Click on `View CloudWatch logs`
+- Click on the latest log stream under `Log streams`
+- Look for any `Error` or `Info` logs that can help determine the reason for failure to rotate the token
+
+
+## Adding Rotation Lambda to same VPC as Timestream for InfluxDB
+**Note** - This is not required, but is a configuration option for users requiring the `InfluxDB Rotation Lambda` to run on the same `VPC` as their `Timestream for InfluxDB` Instance.
+
+1. Adding the `InfuxDB Rotation Lambda` to a `VPC` will require the addition of a `NAT Gateway`
+- We will create three `Subnets`(One for each `availability zone`) pointing to one `Route table` that routes to the `NAT Gateway`
+- Your `Timestream for InfluxDB` instance should already have a `VPC` with a `Subnet` and `Route Table` to an `Internet Gateway`
+- If your `VPC` already has a `NAT Gateway` with appropriate `Subnet` and `Route Tables`, you can skip to step `#5`
+
+<br>
+
+2. Create a `NAT Gateway`
+- If you already have a `NAT Gateway`, skip to step `#3`
+- Click on `NAT Gateway` in the left side bar
+- Click on `Create NAT Gateway`
+- Fill in the `Name` of your choosing, and select the `Subnet` to be `lambda-subnet-point-to-ig` that you created earlier
+- Select `Public` for `Connectivity type` and click `Allocate elastic IP`
+- Click `Create NAT Gateway`
+
+<br>
+
+3. Create a `Route Table` for the `NAT Gateway`
+- If you already have a route to a `NAT Gateway`, skip to step `#4`
+- Click on `Route tables` in the left side bar
+- Click `Create route table`
+- Fill in the `Name` portion and select the `VPC`
+- Click `Create route`
+- Click on `Edit routes` and `Add route`
+- Select `0.0.0.0/0` for the `Destination`
+- Select `NAT Gateway` for `Target` and fill in the `NAT Gateway` we created earlier
+- Click `Save Changes`
+
+<br>
+
+4. Adding `Subnets` for the `Nat Gateway`
+- If you already have three `Subnets` for the `NAT Gateway`, skip to step `#5`
+- Navigate to `VPC` and select `Subnets` in the left side bar
+- Click `Create subnet` and select the `VPC ID` of your `VPC`
+- We will create three subnets pointing to the `NAT Gateway`, each incrementing the second to last byte of the `IPv4 subnet CIDR block` address by 16, ensure these addresses don't overlap with already existing `Subnets`
+- Each `Subnet` will be in their own `availability zone`
+- See the following table for reference, and set the IP's dependent on your `VPC IPv4 CIDR`
+
+<br>
+
+| VPC | CIDR | Name |
+| --- | ---- | --- |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.0.0/20  | lambda-subnet-point-to-nat-1 |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.16.0/20 | lambda-subnet-point-to-nat-2 |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.32.0/20 | lambda-subnet-point-to-nat-3 |
+
+- Click on the `Create Subnet` for each `Subnet` in the table
+
+<br>
+
+5. Setup `InfluxDB Rotation Lambda`
+- Navigate to `Lambda` and select the `InfluxDB Rotation Lambda`
+- Click on `Configuration` and select `VPC` in the left side bar
+- Click on `Edit` under `VPC`
+- Select the `VPC` of the `Timestream for InfluxDB` instance
+- Select the three subnets pointing to the `NAT Gateway`
+- Select the default security group
+- Click `Save`
+
+<br>
+
+6. Your `InfluxDB Rotation Lambda` should now have internet access
+- Below I have listed all required components to the VPC for referece
+- Your configuration may look different, but if you have a `Route` from your private `Subnets` to a `NAT Gateway` linking through to the `Internet Gateway`, the lambda function should have internet access
+
+<br>
+
+| VPC | CIDR | Name | Route Table | Network Connection |
+| --- | ---- | --- | --- | --- |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.0.0/20  | lambda-subnet-point-to-nat-1 | route-to-nat-gw | NAT Gateway |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.16.0/20 | lambda-subnet-point-to-nat-2 | route-to-nat-gw | NAT Gateway |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.32.0/20 | lambda-subnet-point-to-nat-3 | route-to-nat-gw | NAT Gateway |
+| vpc-123abc123abc (ip.of.your.vpc/16) | 123.123.48.0/20 | lambda-subnet-point-to-ig    | route-to-ig     | Internet Gateway |
+
+## VPC Network Configuration Diagram
+
+![image](UML/InfluxDB-Rotation-Lambda-Network-Configuration.png)
+
+## Testing
+
+### Integration Tests
+
+To run the integration tests using the default region defined in the `AWS_DEFAULT_REGION` environment variable, execute the following while your shell is in the `integration` directory:
+
+```shell
+python3 integration_test.py
+```
+
+If the `AWS_DEFAULT_REGION` environment variable is not set or you wish to use a different region, the `--region <region name>` argument will let you set the region to use.
+
+The integration tests will use `boto3` to create a new Timestream for InfluxDB instance (size medium with 20GB of of storage), a VPC required for the Timestream for InfluxDB instance, a lambda function containing `lambda_function.py` and dependencies, and an admin secret, which will be rotated. The integration tests tags these resources; if resources with these tags already exist, then these existing resources will be used.
+
+In addition to the above-mentioned `--region` argument, the integration tests support inividual test arguments, such as running an individual test with `python3 integration_test.py SecretsTestCase.test_operator_token_rotation`, and the option to delete all tagged integration test resources after testing by using `--cleanup`.
+
+> **NOTE**: The secret created by the IT test should not be deleted via the AWS console, as deletion via the AWS console puts secrets into a pending deletion stage where secrets will still be identified by the integration tests. If you wish to delete the integration test secret manually, without using `--cleanup`, delete it using the AWS CLI with `aws secretsmanager delete-secret --secret-id <secret ID> --force-delete-without-recovery`.

--- a/SecretsManagerInfluxDBSingleUserRotation/README.md
+++ b/SecretsManagerInfluxDBSingleUserRotation/README.md
@@ -293,7 +293,7 @@ Username and Password Credentials (for rotating admin user password)
 <br>
 
 6. Your `InfluxDB Rotation Lambda` should now have internet access
-- Below I have listed all required components to the VPC for referece
+- Below I have listed all required components to the VPC for reference
 - Your configuration may look different, but if you have a `Route` from your private `Subnets` to a `NAT Gateway` linking through to the `Internet Gateway`, the lambda function should have internet access
 
 <br>

--- a/SecretsManagerInfluxDBSingleUserRotation/README.md
+++ b/SecretsManagerInfluxDBSingleUserRotation/README.md
@@ -1,7 +1,7 @@
 # Amazon InfluxDB Single User Rotator
 
 ## Getting Started
-The InfluxDB Single-User Rotator rotates a user's authorization token or credentials using the AWS Secrets Manager. The Single-user rotator operates by using the users authentication token or credentials to rotate their token or credentials with new permission identical equivalents. The user token performing the rotation must have the permissions to perform the rotation. For token rotation the type of the token could be an `operator` or `allAccess` token to successfully complete rotation.
+The InfluxDB Single-User Rotator rotates a user's authorization token or credentials using the AWS Secrets Manager. The Single-user rotator operates by using the user's authentication token or credentials to rotate their token or credentials with new permission identical equivalents. The user token performing the rotation must have the permissions to perform the rotation. For token rotation the type of the token could be an `operator` or `allAccess` token to successfully complete rotation.
 
 ### InfluxDB Single-user Token Rotation State Diagram
 The InfluxDB Single-user Token Rotation State Diagram illustrates how a secret authenticates the rotation of their own user or token with each successful step provided by the `Secrets Manager`.
@@ -119,7 +119,7 @@ Username and Password Credentials (for rotating admin user password)
 
 ## Deploy Lambda
 1. Execute script with the following command (Requires pip3 installed)
-- If you are using MacOS or Linux, execute the following commands
+- If you are using macOS or Linux, execute the following commands
   - `./build_deployment.sh`_(to build deployable lambda function package from the source code)_
   - Execute the following command to add execution permissions to your deployment package
   - `sudo chmod +x influxdb-token-rotation-lambda.zip`

--- a/SecretsManagerInfluxDBSingleUserRotation/build_deployment.ps1
+++ b/SecretsManagerInfluxDBSingleUserRotation/build_deployment.ps1
@@ -1,0 +1,96 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Ensure that binary is installed in the local environment
+Function check_command_installed ($Command) {
+    if (-Not (Get-Command $Command -errorAction SilentlyContinue))
+    {
+        Write-Output "$Command could not be found, please install it and re-run this script."
+        exit 1
+    }
+}
+
+# Get user input to verify that the binary installed has the expected path value
+Function binary_input_verification ($BinaryName, $BinaryPath) {
+    Write-Host "This script uses $BinaryName with the following absolute path:"
+    Write-Host $BinaryPath 
+    Write-Host "If this is the expected path for $BinaryName then type 'y' to continue: "
+    $continue_confirmation = Read-Host -Prompt "y/n"
+
+    if (-Not ([string]$continue_confirmation -eq "y"))
+    {
+        Write-Host "Script Aborted"
+        exit 1
+    }
+}
+
+# Output the help dialogue for how to use this script
+Function show_help_dialogue()
+{
+    Write-Output "
+        Usage: build_deployment.ps1 [-F Format] [-L Linter] [-D Deploy]
+
+        -F Format       Run the ruff formatter.
+        -L Linter       Run the ruff linter.
+        -D Deploy       Build and package the deployment.
+
+        For Example: ./build_deployment.ps1 -D
+    "
+}
+
+if ($($args.Count) -eq 0)
+{
+    show_help_dialogue
+    exit 1
+}
+
+ForEach ($arg in $args) {
+    switch -Exact ($arg)
+    {
+        {($_ -eq "-F") -or ($_ -eq "-L")}
+        {
+            check_command_installed "ruff";
+            $ruff_installed_path=$(Get-Command "ruff").Source
+            binary_input_verification "ruff" $ruff_installed_path
+            if ($_ -eq "-F")
+            {
+                Write-Output "Running Formatter";
+                ruff format
+            }
+            else
+            {
+                Write-Output "Running Linter";
+                ruff check
+            }
+            exit 1            
+        }
+        {($_ -eq "-D")} 
+        {
+            Write-Output "Building Deployment";
+            break
+        }
+        Default 
+        {
+            Write-Output "Invalid option: $arg";
+            exit 1
+        }
+    }
+}
+
+# Ensure pip3 is installed and verify the binary location
+check_command_installed "pip3"
+$pip3_installed_path=$(Get-Command "pip3").Source
+binary_input_verification "pip3" $pip3_installed_path
+
+# Make a temporary directory and populate with dependencies
+mkdir tmp-influxdb-deployment-lambda
+cd tmp-influxdb-deployment-lambda
+pip3 install -r ..\requirements.txt -t . --no-user
+
+# Copy the lambda function code and create a zip of lambda with dependencies
+copy ..\lambda_function.py .\
+Compress-Archive -Path * -DestinationPath ..\influxdb-token-rotation-lambda.zip -CompressionLevel Optimal -Force
+
+# Cleanup
+cd ..\
+Remove-Item -Path .\tmp-influxdb-deployment-lambda -Force -Recurse

--- a/SecretsManagerInfluxDBSingleUserRotation/build_deployment.sh
+++ b/SecretsManagerInfluxDBSingleUserRotation/build_deployment.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Ensure that binary is installed in the local environment
+check_command_installed () {
+    bin_path=$(command -v $1)
+    if [ "${bin_path}" == "" ];
+    then
+        echo "$1 could not be found, please install it and re-run this script." >&2
+        exit 1
+    fi
+    echo "$bin_path"
+}
+
+# Output the help dialogue for how to use this script
+show_help_dialogue()
+{
+echo "
+        Usage: build_deployment.sh [-F Format] [-L Linter] [-D Deploy]
+
+        -F Format       Run the ruff formatter.
+        -L Linter       Run the ruff linter.
+        -D Deploy       Build and package the deployment.
+
+        For Example: ./build_deployment.sh -D
+"
+}
+
+if [ $# -eq 0 ]
+then
+  show_help_dialogue
+  exit 1
+fi
+
+while getopts "FLD" flag; do
+  case $flag in
+    F|L)
+      ruff_bin_path="$(check_command_installed "ruff")"
+      [ -z "${ruff_bin_path}" ] && exit 1
+      echo "This script uses the ruff binary with the following absolute path:"
+      echo "$ruff_bin_path"
+      read -p "If this is the expected path for this binary type 'y' to continue: " -r
+      if [ "$flag" == "F" ]
+      then
+        echo "Running Formatter"
+        format_result=$(ruff format)
+        echo "$format_result"
+      else
+        echo "Running Linter"
+        lint_result=$(ruff check)
+        echo "$lint_result"
+      fi
+      exit 1
+      ;;
+    D)
+      echo "Building Deployment"
+      ;;
+    \?)
+      echo "Invalid option: -$flag"
+      exit 1
+      ;;
+  esac
+done
+
+# Ensure pip3 and zip is installed
+pip3_bin_path="$(check_command_installed "pip3")"
+[ -z "${pip3_bin_path}" ] && exit 1
+zip_bin_path="$(check_command_installed "zip")"
+[ -z "${zip_bin_path}" ] && exit 1
+
+# Verify the installed binary locations are in the expected locations
+echo "This script uses pip3 and zip binaries with the following absolute paths:"
+echo "$pip3_bin_path"
+echo "$zip_bin_path"
+read -p "If these are the expected paths for these binaries type 'y' to continue: " -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo "Script Aborted"
+    exit 1
+fi
+
+# Make a temporary directory and populate with dependencies
+mkdir tmp-influxdb-deployment-lambda
+cd tmp-influxdb-deployment-lambda
+pip3 install -r ../requirements.txt -t .
+
+# Copy the lambda function code and create a zip of lambda with dependencies
+cp ../lambda_function.py ./
+
+zip -r ../influxdb-token-rotation-lambda.zip .
+
+# Cleanup
+cd ../
+rm -rf tmp-influxdb-deployment-lambda

--- a/SecretsManagerInfluxDBSingleUserRotation/integration/aws_integration_test_client.py
+++ b/SecretsManagerInfluxDBSingleUserRotation/integration/aws_integration_test_client.py
@@ -250,7 +250,7 @@ class AWSIntegrationTestClient:
             stdout=subprocess.PIPE,
             cwd=os.path.pardir,
         )
-        archive_path = Path("./influxdb-token-rotation-lambda.zip")
+        archive_path = Path("../influxdb-token-rotation-lambda.zip")
         if not archive_path.is_file():
             logger.error("Building rotation lambda function deployment failed")
             return

--- a/SecretsManagerInfluxDBSingleUserRotation/integration/aws_integration_test_client.py
+++ b/SecretsManagerInfluxDBSingleUserRotation/integration/aws_integration_test_client.py
@@ -15,7 +15,6 @@ from integration_test_utils import random_string, logger
 
 class AWSIntegrationTestClient:
     ROTATION_TIMEOUT_SECONDS = 60
-    VERSION_ID_LENGTH = 32  # Minimum accepted version ID length
     LAMBDA_FUNCTION_TAG_KEY = "tmp-influxdb-integration-test-lambda-function"
     LAMBDA_FUNCTION_TAG_VALUE = "single-user-rotation-integration-lambda"
     LAMBDA_FUNCTION_RUNTIME = "python3.12"

--- a/SecretsManagerInfluxDBSingleUserRotation/integration/aws_integration_test_client.py
+++ b/SecretsManagerInfluxDBSingleUserRotation/integration/aws_integration_test_client.py
@@ -1,0 +1,496 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import json
+from pathlib import Path
+from sys import platform
+import time
+import subprocess
+import uuid
+import os
+
+import boto3
+from integration_test_utils import random_string, logger
+
+
+class AWSIntegrationTestClient:
+    ROTATION_TIMEOUT_SECONDS = 60
+    VERSION_ID_LENGTH = 32  # Minimum accepted version ID length
+    LAMBDA_FUNCTION_TAG_KEY = "tmp-influxdb-integration-test-lambda-function"
+    LAMBDA_FUNCTION_TAG_VALUE = "single-user-rotation-integration-lambda"
+    LAMBDA_FUNCTION_RUNTIME = "python3.12"
+    LAMBDA_FUNCTION_TIMEOUT_SECONDS = 180  # Three minutes
+    SECRET_TAG_KEY = "tmp-influxdb-integration-test-secret"
+    ADMIN_SECRET_TAG_VALUE = "single-user-rotation-integration-test-admin-secret"
+
+    _boto3_session: boto3.Session
+    _secrets_client = None
+    _resource_client = None
+    _lambda_client = None
+    _region_name: str
+
+    admin_secret_arn: str = ""
+    rotation_lambda_name: str = ""
+    rotation_lambda_arn: str = ""
+    version_id: str = ""
+
+    def __init__(self, region_name) -> None:
+        self._region_name = region_name
+        self._boto3_session = boto3.Session(region_name=self._region_name)
+        self._secrets_client = self._boto3_session.client("secretsmanager")
+        self._resource_client = self._boto3_session.client("resourcegroupstaggingapi")
+        self._lambda_client = self._boto3_session.client("lambda")
+
+    def get_aws_resources_by_tag(self, tag_key, tag_value):
+        """
+        Returns AWS resources using its tag key and tag value.
+
+        :param str tag_key: The key of the tag.
+        :param str tag_value: The value of the tag.
+        :return: The resource information as a dict.
+        """
+        try:
+            resources = self._resource_client.get_resources(
+                TagFilters=[{"Key": tag_key, "Values": [tag_value]}]
+            )["ResourceTagMappingList"]
+            return resources
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error(f"Failed to get resource with tag {tag_key}:{tag_value}")
+            raise
+
+    def create_admin_secret(
+        self, engine, username, password, token, influxdb_id, org_name
+    ):
+        """
+        Creates the admin secret dict in Secrets Manager, populating it with the provided values.
+
+        :param str engine: The type of engine, "timstream-influxdb" is typical.
+        :param str username: The username of the admin.
+        :param str password: The password for the admin.
+        :param str token: The token for the admin.
+        :param str influxdb_id: The ID of the Timestream for InfluxDB instance where the admin exists.
+        :param str org_name: The name of the existing org in the Timestream for InfluxDB instance to use.
+        :return: None
+        """
+        try:
+            secret_dict = {
+                "engine": engine,
+                "username": username,
+                "password": password,
+                "token": token,
+                "static_operator_token": token,
+                "dbIdentifier": influxdb_id,
+                "org": org_name,
+            }
+            return self._secrets_client.create_secret(
+                Name=self.ADMIN_SECRET_TAG_VALUE + random_string(10),
+                Description="A secret used for integration tests with the InfluxDB token single-user rotation Lambda. "
+                "This secret holds admin values, and will be rotated.",
+                SecretString=json.dumps(secret_dict),
+                Tags=[
+                    {"Key": self.SECRET_TAG_KEY, "Value": self.ADMIN_SECRET_TAG_VALUE}
+                ],
+            )
+        except Exception:
+            logger.error("Admin secret could not be created")
+            raise
+
+    def init_secrets(self, engine, username, password, token, influxdb_id, org_name):
+        """
+        Initializes admin secret, getting its ARN, and creating it if needed.
+
+        :param str engine: The type of engine, "timstream-influxdb" is typical. To be used
+            to create a new admin secret if an existing admin secret cannot be found.
+        :param str username: The username of the admin. To be used
+            to create a new admin secret if an existing admin secret cannot be found.
+        :param str password: The password for the admin. To be used
+            to create a new admin secret if an existing admin secret cannot be found.
+        :param str token: The token for the admin. To be used
+            to create a new admin secret if an existing admin secret cannot be found.
+        :param str influxdb_id: The ID of the Timestream for InfluxDB instance where the admin exists. To be used
+            to create a new admin secret if an existing admin secret cannot be found.
+        :param str org_name: The name of the existing org in the Timestream for InfluxDB instance to use. To be used
+            to create a new admin secret if an existing admin secret cannot be found.
+        :return: None
+        """
+        existing_admin_secrets = self.get_aws_resources_by_tag(
+            tag_key=self.SECRET_TAG_KEY, tag_value=self.ADMIN_SECRET_TAG_VALUE
+        )
+        if len(existing_admin_secrets) > 0:
+            self.admin_secret_arn = existing_admin_secrets[0]["ResourceARN"]
+            logger.info("Existing admin secret found")
+        else:
+            logger.info("No existing admin secret could be found, creating new secret")
+            create_admin_secret_response = self.create_admin_secret(
+                engine, username, password, token, influxdb_id, org_name
+            )
+            self.admin_secret_arn = create_admin_secret_response["ARN"]
+
+    def init_lambda_function(self, influxdb_arn):
+        """
+        Initializes the rotation lambda function, getting its ARN and name, and creating it
+            if needed.
+
+        :param str influxdb_arn: The ARN of the Timestream for InfluxDB instance, to be used to create
+            permissions for the lambda function if it doesn't already exist.
+        :return: None
+        """
+        # Check whether the lambda function already exists
+        existing_lambda_functions = self.get_aws_resources_by_tag(
+            tag_key=self.LAMBDA_FUNCTION_TAG_KEY,
+            tag_value=self.LAMBDA_FUNCTION_TAG_VALUE,
+        )
+        if len(existing_lambda_functions) > 0:
+            logger.info("Existing lambda rotation function found")
+            self.rotation_lambda_arn = existing_lambda_functions[0]["ResourceARN"]
+            try:
+                rotation_lambda = self._lambda_client.get_function(
+                    FunctionName=self.rotation_lambda_arn
+                )
+                self.rotation_lambda_name = rotation_lambda["Configuration"][
+                    "FunctionName"
+                ]
+            except Exception:
+                logger.error(
+                    f"Getting rotation lambda function name for lambda function {self.rotation_lambda_arn} failed"
+                )
+                raise
+        # Lambda function does not exist, create it
+        else:
+            logger.info("No existing rotation lambda function could be found")
+            self.create_new_lambda_function(influxdb_arn=influxdb_arn)
+
+    def create_new_lambda_function(self, influxdb_arn):
+        """
+        Creates a new rotation lambda function.
+
+        :param str influxdb_arn: The ARN of the Timestream for InfluxDB instance, to be used to
+            set permissions for the lambda function.
+        :return: None
+        """
+        # Create permissions for lambda function
+        iam_client = boto3.client("iam", region_name=self._region_name)
+        trust_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "lambda.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+        lambda_role_name = self.LAMBDA_FUNCTION_TAG_VALUE + "-role" + random_string(5)
+        role_create_response = iam_client.create_role(
+            RoleName=lambda_role_name, AssumeRolePolicyDocument=json.dumps(trust_policy)
+        )
+        lambda_role_arn = role_create_response["Role"]["Arn"]
+        lambda_policy_name = (
+            self.LAMBDA_FUNCTION_TAG_VALUE + "-policy" + random_string(5)
+        )
+        account_id = boto3.client("sts").get_caller_identity().get("Account")
+        lambda_permissions = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "logs:CreateLogGroup",
+                    "Resource": f"arn:aws:logs:{self._region_name}:{account_id}:*",
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+                    "Resource": [
+                        f"arn:aws:logs:{self._region_name}:{account_id}:log-group:/aws/lambda/{self.LAMBDA_FUNCTION_TAG_VALUE}*:*"
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "secretsmanager:DescribeSecret",
+                        "secretsmanager:GetSecretValue",
+                        "secretsmanager:PutSecretValue",
+                        "secretsmanager:UpdateSecretVersionStage",
+                    ],
+                    "Resource": [f"{self.admin_secret_arn}"],
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": ["secretsmanager:GetRandomPassword"],
+                    "Resource": "*",
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "timestream-influxdb:GetDbInstance",
+                    ],
+                    "Resource": [f"{influxdb_arn}"],
+                },
+            ],
+        }
+        iam_client.put_role_policy(
+            RoleName=lambda_role_name,
+            PolicyName=lambda_policy_name,
+            PolicyDocument=json.dumps(lambda_permissions),
+        )
+
+        # Create lambda function
+        logger.info("Building lambda deployment")
+        package_command = []
+        if platform == "win32":
+            package_command = [".\\build_deployment.ps1", "-D"]
+        else:
+            package_command = ["./build_deployment.sh", "-D"]
+        subprocess.run(
+            package_command,
+            shell=False,
+            input="y\n",
+            text=True,
+            stdout=subprocess.PIPE,
+            cwd=os.path.pardir,
+        )
+        archive_path = Path("./influxdb-token-rotation-lambda.zip")
+        if not archive_path.is_file():
+            logger.error("Building rotation lambda function deployment failed")
+            return
+        logger.info("Creating lambda function")
+        self.rotation_lambda_name = self.LAMBDA_FUNCTION_TAG_VALUE + random_string(5)
+        with open(archive_path, "rb") as archive:
+            lambda_create_response = self._lambda_client.create_function(
+                FunctionName=self.rotation_lambda_name,
+                Runtime=self.LAMBDA_FUNCTION_RUNTIME,
+                Handler="lambda_function.lambda_handler",
+                Role=lambda_role_arn,
+                Timeout=self.LAMBDA_FUNCTION_TIMEOUT_SECONDS,
+                Code={"ZipFile": archive.read()},
+                PackageType="Zip",
+                Environment={
+                    "Variables": {
+                        "SECRETS_MANAGER_ENDPOINT": f"https://secretsmanager.{self._region_name}.amazonaws.com"
+                    }
+                },
+                Tags={self.LAMBDA_FUNCTION_TAG_KEY: self.LAMBDA_FUNCTION_TAG_VALUE},
+            )
+        self.rotation_lambda_arn = lambda_create_response["FunctionArn"]
+
+        # Allow secrets manager to invoke the lambda function
+        self._lambda_client.add_permission(
+            FunctionName=self.rotation_lambda_arn,
+            StatementId="SecretsMangerInvoke",
+            Action="lambda:InvokeFunction",
+            Principal="secretsmanager.amazonaws.com",
+            SourceArn=self.admin_secret_arn,
+        )
+
+    def set_version_id(self, version_id=None):
+        """
+        Sets the version ID of the current secret, locally.
+        If version_id is not provided, a uuid is generated.
+
+        :param str version_id: The version ID to set, must be at least 32 characters in length.
+        :return: None
+        """
+        if version_id is not None:
+            self.version_id = version_id
+        else:
+            self.version_id = str(uuid.uuid4())
+
+    def cancel_rotate_admin_secret(self):
+        """
+        Cancels any ongoing rotation of the admin secret and removes AWSPENDING from any
+            version of the admin secret.
+
+        :return: None
+        """
+        self._secrets_client.cancel_rotate_secret(SecretId=self.admin_secret_arn)
+        self.remove_pending(arn=self.admin_secret_arn)
+
+    def wait_for_rotation(self, arn):
+        """
+        Waits for a rotation to end, whether with success or failure.
+
+        :return: bool, whether the rotation succeeded.
+        """
+        # The only reliable way to determine whether a rotation succeeded is to check whether
+        # the version ID has been set
+        timeout = time.time() + self.ROTATION_TIMEOUT_SECONDS
+        while time.time() < timeout:
+            try:
+                self._secrets_client.get_secret_value(
+                    SecretId=arn,
+                    VersionId=self.version_id,
+                    VersionStage="AWSCURRENT",
+                )
+                return True
+            except (
+                self._secrets_client.exceptions.ResourceNotFoundException,
+                self._secrets_client.exceptions.InvalidRequestException,
+            ):
+                pass
+            time.sleep(5)
+        return False
+
+    def rotate_admin_secret(self):
+        """
+        Rotates the admin secret using the rotation lambda and a new version ID.
+
+        :return: bool, whether the rotation succeeded.
+        """
+        # There should not be any rotations currently in progress, removing the AWSPENDING stage
+        # will keep rotate_secret from believing a rotation is in progress
+        self.cancel_rotate_admin_secret()
+        self.remove_pending(self.admin_secret_arn)
+        self.set_version_id()
+        try:
+            self._secrets_client.rotate_secret(
+                SecretId=self.admin_secret_arn,
+                ClientRequestToken=self.version_id,
+                RotationLambdaARN=self.rotation_lambda_arn,
+                RotateImmediately=True,
+            )
+        except (
+            self._secrets_client.exceptions.InvalidRequestException,
+            self._secrets_client.exceptions.ResourceNotFoundException,
+        ):
+            raise
+        return self.wait_for_rotation(self.admin_secret_arn)
+
+    def post_admin_secret(self, secret_dict):
+        """
+        Updates the admin secret in Amazon Secrets Manager to contain the values in secret_dict.
+
+        :param dict secret_dict: The dict to use in Secrets Manager as the admin secret.
+        :return: None
+        """
+        self.set_version_id()
+        try:
+            self._secrets_client.update_secret(
+                SecretId=self.admin_secret_arn,
+                ClientRequestToken=self.version_id,
+                SecretString=json.dumps(secret_dict),
+            )
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error("Failed to update admin secret")
+
+    def set_create_auth(self, create_auth):
+        """
+        Sets the environment variable of the rotation lambda to allow it to create
+            credentials or tokens if necessary.
+
+        :param bool create_auth: The value to set the environment variable to.
+        :return: None
+        """
+        create_auth_str = "false"
+        if create_auth:
+            create_auth_str = "true"
+        self._lambda_client.update_function_configuration(
+            FunctionName=self.rotation_lambda_arn,
+            Environment={
+                "Variables": {
+                    "SECRETS_MANAGER_ENDPOINT": f"https://secretsmanager.{self._region_name}.amazonaws.com",
+                    "AUTHENTICATION_CREATION_ENABLED": create_auth_str,
+                }
+            },
+        )
+        # Wait for configuration to change
+        timeout = time.time() + 60  # One minute from now
+        while time.time() < timeout:
+            response = self._lambda_client.get_function_configuration(
+                FunctionName=self.rotation_lambda_arn
+            )
+            if (
+                "LastUpdateStatus" in response
+                and response["LastUpdateStatus"] == "Successful"
+            ):
+                logger.debug(
+                    f'Successfully updated create auth value to "{create_auth_str}"'
+                )
+                break
+            elif (
+                "LastUpdateStatus" in response
+                and response["LastUpdateStatus"] == "Failed"
+            ):
+                logger.error(
+                    f'Failed to udpate create auth environment variable to "{create_auth_str}"'
+                )
+                break
+            # Still in progress
+            time.sleep(5)
+        if time.time() >= timeout:
+            logger.error(
+                f'Failed to udpate create auth environment variable to "{create_auth_str}"'
+            )
+
+    def remove_pending(self, arn):
+        """
+        Removes the AWSPENDING stage from any and all version IDs for a secret.
+            The existence of an AWSPENDING stage can cause the secrets manager to consider a secret
+            still in rotation.
+
+        :param str arn: The secret ARN to remove the AWSPENDING stage from.
+        :return: None
+        """
+        try:
+            versions = self._secrets_client.describe_secret(SecretId=arn)[
+                "VersionIdsToStages"
+            ]
+            for key, val in versions.items():
+                if "AWSPENDING" in val:
+                    self._secrets_client.update_secret_version_stage(
+                        RemoveFromVersionId=key,
+                        SecretId=arn,
+                        VersionStage="AWSPENDING",
+                    )
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error("Removing AWSPENDING stage from secret version failed")
+
+    def get_admin_secret_dict(self):
+        """
+        Gets and returns the admin secret, as a dict, from Secrets Manager.
+
+        :return: dict, the admin secret.
+        """
+        return json.loads(
+            self._secrets_client.get_secret_value(SecretId=self.admin_secret_arn)[
+                "SecretString"
+            ]
+        )
+
+    def teardown(self):
+        """
+        Deletes all resources created by AWSIntegrationTestClient.
+
+        :return: None
+        """
+        self.delete_admin_secret()
+        self.delete_lambda()
+
+    def delete_admin_secret(self):
+        """
+        Finds and deletes the admin secret in Secrets Manager by using its ARN.
+
+        :return: None
+        """
+        logger.info("Deleting user secret")
+        try:
+            self._secrets_client.delete_secret(
+                SecretId=self.admin_secret_arn, ForceDeleteWithoutRecovery=True
+            )
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error("Failed to delete admin secret")
+
+    def delete_lambda(self):
+        """
+        Finds and deletes the rotation lambda using its name.
+
+        :return: None
+        """
+        try:
+            self._lambda_client.delete_function(FunctionName=self.rotation_lambda_arn)
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error("Failed to delete lambda function")

--- a/SecretsManagerInfluxDBSingleUserRotation/integration/influxdb_integration_test_client.py
+++ b/SecretsManagerInfluxDBSingleUserRotation/integration/influxdb_integration_test_client.py
@@ -1,0 +1,597 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import json
+import time
+import sys
+
+import boto3
+from botocore.exceptions import ClientError
+import influxdb_client
+from influxdb_client.rest import ApiException
+from integration_test_utils import random_string, logger
+
+sys.path.insert(0, "../../SecretsManagerInfluxDBMultiUserRotation")
+from lambda_function import create_operator_token_perms
+
+
+class InfluxDBIntegrationTestClient:
+    SLEEP_SECONDS = 15
+    MAXIMUM_WAIT_SECONDS = 1200  # 20 minutes
+    TIMESTREAM_INFLUXDB_ENGINE = "timestream-influxdb"
+    NON_EXISTENT_USERNAME = "gregstopher"
+    VPC_TAG_KEY = "tmp-influxdb-integration-test-vpc"
+    INFLUXDB_INSTANCE_TAG_KEY = "tmp-influxdb-integration-test-db"
+    INFLUXDB_INSTANCE_TAG_VALUE = "single-user-rotation-integration-db"
+    INFLUXDB_ADMIN_USERNAME = "admin"
+    INFLUXDB_ORG_NAME = "org"
+    INFLUXDB_BUCKET = "test-bucket"
+    INFLUXDB_TYPE = "db.influx.medium"
+    _region_name: str
+    _boto3_session = None
+    _resource_client = None
+    _timestream_influxdb_client = None
+    _secrets_client = None
+    _ec2 = None
+    _ec2_client = None
+
+    # influxdb_client must be accessed and closed by integration_test
+    # because influxdb_client.__del__ does an import during program shutdown
+    # which causes alarming logs
+    influxdb_client = None
+    current_auth = None
+    static_operator_token: str = ""
+    influxdb_admin_id: str = ""
+    influxdb_admin_password: str = ""
+    influxdb_arn: str = ""
+    influxdb_endpoint: str = ""
+    influxdb_id: str = ""
+    influxdb_org_id: str = ""
+    vpc_id: str = ""
+
+    def __init__(self, region_name) -> None:
+        self._region_name = region_name
+        self._boto3_session = boto3.Session(region_name=self._region_name)
+        self._resource_client = self._boto3_session.client("resourcegroupstaggingapi")
+        self._timestream_influxdb_client = self._boto3_session.client(
+            "timestream-influxdb"
+        )
+        self._secrets_client = self._boto3_session.client("secretsmanager")
+        self._ec2 = self._boto3_session.resource("ec2", region_name=self._region_name)
+        self._ec2_client = self._ec2.meta.client
+
+    def get_influxdb_resources_by_tag(self, tag_key, tag_value):
+        """
+        Returns Timestream for InfluxDB resources using its tag key and tag value.
+
+        :param str tag_key: The key of the tag.
+        :param str tag_value: The value of the tag.
+        :return: The resource information as a dict.
+        """
+        try:
+            resources = self._resource_client.get_resources(
+                TagFilters=[{"Key": tag_key, "Values": [tag_value]}]
+            )["ResourceTagMappingList"]
+            return resources
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error(f"Failed to get resource with tag {tag_key}:{tag_value}")
+            raise
+
+    def init_timestream_for_influxdb(self):
+        """
+        Initializes Timestream for InfluxDB, creating a Timestream for InfluxDB instance
+            if needed, along with its VPC.
+
+        :return: None
+        """
+        existing_test_dbs = self.get_influxdb_resources_by_tag(
+            tag_key=self.INFLUXDB_INSTANCE_TAG_KEY,
+            tag_value=self.INFLUXDB_INSTANCE_TAG_VALUE,
+        )
+
+        # Test whether instance already exists
+        if len(existing_test_dbs) > 0:
+            logger.info("Existing Timestream for InfluxDB instance found")
+            self.influxdb_arn = existing_test_dbs[0]["ResourceARN"]
+            self.use_existing_timestream_influxdb_instance()
+        # Test instance does not exist, create it
+        else:
+            logger.info("No existing Timestream for InfluxDB instance could be found")
+            self.create_new_timestream_influxdb_instance()
+
+    def use_existing_timestream_influxdb_instance(self):
+        """
+        Populates AWS values associated with the Timestream for InfluxDB test
+            instance, such as its ID, endpoint, stored password, and ARN.
+
+        :return: None
+        """
+        try:
+            instances = self._timestream_influxdb_client.list_db_instances()
+
+            for instance in instances["items"]:
+                if instance["arn"] == self.influxdb_arn:
+                    self.influxdb_id = instance["id"]
+            while self.influxdb_id == "" and instances["nextToken"] != "":
+                for instance in instances["items"]:
+                    if instance["arn"] == self.influxdb_arn:
+                        self.influxdb_id = instance["id"]
+                instances = self._timestream_influxdb_client.list_db_instances(
+                    nextToken=instances["nextToken"]
+                )
+
+            if self.influxdb_id == "":
+                raise ValueError(
+                    "ERROR: Metadata for existing Timestream for InfluxDB instance could not be retrieved"
+                )
+
+            instance_secret_arn = self._timestream_influxdb_client.get_db_instance(
+                identifier=self.influxdb_id
+            )["influxAuthParametersSecretArn"]
+            self.influxdb_admin_password = json.loads(
+                self._secrets_client.get_secret_value(SecretId=instance_secret_arn)[
+                    "SecretString"
+                ]
+            )["password"]
+
+            self.influxdb_endpoint = self._timestream_influxdb_client.get_db_instance(
+                identifier=self.influxdb_id
+            )["endpoint"]
+
+            self.get_default_influxdb_metadata()
+        except Exception as error:
+            logger.error(repr(error))
+            raise
+
+    def get_default_influxdb_metadata(self):
+        """
+        Gets default Timestream for InfluxDB metadata, such as admin user ID,
+            operator token, and primary org ID, using the InfluxDB client.
+
+        :return: None
+        """
+        try:
+            self.influxdb_client = influxdb_client.InfluxDBClient(
+                url=f"https://{self.influxdb_endpoint}:8086",
+                username=self.INFLUXDB_ADMIN_USERNAME,
+                password=self.influxdb_admin_password,
+                org=self.INFLUXDB_ORG_NAME,
+            )
+
+            users = self.influxdb_client.users_api().find_users(
+                name=self.INFLUXDB_ADMIN_USERNAME
+            )
+            if len(users.users) == 0:
+                raise ValueError("Admin user ID could not be found")
+            self.influxdb_admin_id = users.users[0].id
+
+            orgs = self.influxdb_client.organizations_api().find_organizations(
+                org=self.INFLUXDB_ORG_NAME
+            )
+            if len(orgs) == 0:
+                raise ValueError("Primary org could not be found")
+            self.influxdb_org_id = orgs[0].id
+
+            auths = self.influxdb_client.authorizations_api().find_authorizations(
+                org=self.INFLUXDB_ORG_NAME
+            )
+
+            for auth in auths:
+                # The first token, created when the instance is first created,
+                # will have the following description
+                if auth.description == f"{self.INFLUXDB_ADMIN_USERNAME}'s Token":
+                    self.static_operator_token = auth.token
+            if self.static_operator_token == "":
+                raise ValueError(
+                    "The static operator token could not be retrieved from the Timestream for InfluxDB instance"
+                )
+        except Exception:
+            logger.error("Failed to get Timestream for InfluxDB values")
+            raise
+
+    def create_new_timestream_influxdb_instance(self):
+        """
+        Creates a new test Timestream for InfluxDB instance, including its
+            VPC.
+
+        :return: None
+        """
+        try:
+            vpc_create_response = self._ec2_client.create_vpc(
+                CidrBlock="10.0.0.0/16", AmazonProvidedIpv6CidrBlock=False
+            )
+            vpc_id = vpc_create_response["Vpc"]["VpcId"]
+            self._ec2_client.create_tags(
+                Resources=[vpc_id],
+                Tags=[
+                    {"Key": "Name", "Value": "influxdb-integration-vpc"},
+                    {
+                        "Key": self.VPC_TAG_KEY,
+                        "Value": self.INFLUXDB_INSTANCE_TAG_VALUE,  # Tag to help deletion later
+                    },
+                ],
+            )
+            logger.info(f"Created VPC with ID {vpc_id}")
+            self._ec2_client.modify_vpc_attribute(
+                VpcId=vpc_id,
+                EnableDnsSupport={"Value": True},
+            )
+            self._ec2_client.modify_vpc_attribute(
+                VpcId=vpc_id, EnableDnsHostnames={"Value": True}
+            )
+            ig_create_response = self._ec2_client.create_internet_gateway()
+            ig_id = ig_create_response["InternetGateway"]["InternetGatewayId"]
+            self._ec2_client.attach_internet_gateway(
+                InternetGatewayId=ig_id, VpcId=vpc_id
+            )
+            subnet_response = self._ec2_client.create_subnet(
+                VpcId=vpc_id,
+                CidrBlock="10.0.0.0/24",
+                AvailabilityZone=f"{self._region_name}a",
+            )
+            subnet_id = subnet_response["Subnet"]["SubnetId"]
+            route_table_create_response = self._ec2_client.create_route_table(
+                VpcId=vpc_id
+            )
+            self._ec2_client.create_route(
+                RouteTableId=route_table_create_response["RouteTable"]["RouteTableId"],
+                DestinationCidrBlock="0.0.0.0/0",
+                GatewayId=ig_id,
+            )
+            self._ec2_client.associate_route_table(
+                RouteTableId=route_table_create_response["RouteTable"]["RouteTableId"],
+                SubnetId=subnet_id,
+            )
+            security_group_response = self._ec2_client.create_security_group(
+                Description=f"VPC security group for {self.INFLUXDB_INSTANCE_TAG_VALUE}",
+                GroupName=self.INFLUXDB_INSTANCE_TAG_VALUE,
+                VpcId=vpc_id,
+            )
+            security_group_id = security_group_response["GroupId"]
+            self._ec2_client.authorize_security_group_ingress(
+                GroupId=security_group_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 8086,
+                        "ToPort": 8086,
+                        "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                    }
+                ],
+            )
+        except Exception:
+            logger.error("Failed to create VPC and VPC dependencies")
+            raise
+
+        self.influxdb_admin_password = random_string(20)
+
+        logger.info("Creating new Timestream for InfluxDB instance")
+        try:
+            instance = self._timestream_influxdb_client.create_db_instance(
+                name=self.INFLUXDB_INSTANCE_TAG_VALUE + random_string(3),
+                username=self.INFLUXDB_ADMIN_USERNAME,
+                password=self.influxdb_admin_password,
+                organization=self.INFLUXDB_ORG_NAME,
+                bucket=self.INFLUXDB_BUCKET,
+                dbInstanceType=self.INFLUXDB_TYPE,
+                vpcSubnetIds=[subnet_id],
+                vpcSecurityGroupIds=[security_group_id],
+                publiclyAccessible=True,
+                dbStorageType="InfluxIOIncludedT1",
+                allocatedStorage=20,
+                deploymentType="SINGLE_AZ",
+                tags={self.INFLUXDB_INSTANCE_TAG_KEY: self.INFLUXDB_INSTANCE_TAG_VALUE},
+            )
+        except Exception:
+            logger.error("Failed to create Timestream for InfluxDB instance")
+            raise
+
+        self.influxdb_arn = instance["arn"]
+
+        self.influxdb_id = instance["id"]
+
+        try:
+            instance = self._timestream_influxdb_client.get_db_instance(
+                identifier=self.influxdb_id
+            )
+        except Exception:
+            logger.error("Failed to get new Timestream for InfluxDB instance")
+            raise
+
+        elapsed_time = 0
+        while (
+            instance["status"] == "CREATING"
+            and elapsed_time < self.MAXIMUM_WAIT_SECONDS
+        ):
+            time.sleep(self.SLEEP_SECONDS)
+            elapsed_time += self.SLEEP_SECONDS
+            instance = self._timestream_influxdb_client.get_db_instance(
+                identifier=self.influxdb_id
+            )
+            logger.info(f"Creation status: {instance['status']}")
+        if (
+            elapsed_time >= self.MAXIMUM_WAIT_SECONDS
+            and instance["status"] != "AVAILABLE"
+        ):
+            raise ValueError("A Timestream for InfluxDB instance could not be created")
+        else:
+            logger.info(
+                f"New Timestream for InfluxDB instance created with endpoint {instance['endpoint']}, status: {instance['status']}"
+            )
+            # Using an instance too soon can cause issues
+            time.sleep(30)
+            instance = self._timestream_influxdb_client.get_db_instance(
+                identifier=self.influxdb_id
+            )
+
+        logger.info("Getting endpoint")
+        self.influxdb_endpoint = instance["endpoint"]
+        self.get_default_influxdb_metadata()
+
+    def create_current_auth(self, token_perms=None):
+        """
+        Creates a new token in Timestream for InfluxDB and sets
+            InfluxDBIntegrationTestClient.current_auth to this new authorization.
+
+        :param list[influxdb_client.Permission]: A list of Permissions to use to create
+            the authorization.
+        :return: None
+        """
+        if token_perms is None:
+            token_perms = create_operator_token_perms()
+        try:
+            self.current_auth = (
+                self.influxdb_client.authorizations_api().create_authorization(
+                    org_id=self.influxdb_org_id, permissions=token_perms
+                )
+            )
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error("Failed to create new Timestream for InfluxDB token")
+
+    def teardown(self):
+        """
+        Deletes all Timestream for InfluxDB resources, including the Timestream for InfluxDB
+            instance and its VPC.
+
+        :return: None
+        """
+        self.delete_influxdb_instance()
+        # Delete test VPCs as deleting a Timestream for InfluxDB instance won't delete its VPCs
+        # VPCs can only be deleted after the instance has been deleted
+        existing_test_vpcs = self.get_influxdb_resources_by_tag(
+            tag_key=self.VPC_TAG_KEY, tag_value=self.INFLUXDB_INSTANCE_TAG_VALUE
+        )
+        if len(existing_test_vpcs) > 0:
+            for vpc in existing_test_vpcs:
+                vpc_id = vpc["ResourceARN"].split("/")[-1]
+                self.delete_vpc_and_dependencies(vpc_id=vpc_id)
+
+    def delete_influxdb_instance(self):
+        """
+        Deletes the test Timestream for InfluxDB instance. This method will wait
+            for the instance to finish deleting.
+
+        :return: None
+        """
+        logger.info(f"Deleting Timestream for InfluxDB instance {self.influxdb_id}")
+        try:
+            self._timestream_influxdb_client.delete_db_instance(
+                identifier=self.influxdb_id
+            )
+        except Exception:
+            raise
+        try:
+            instance = self._timestream_influxdb_client.get_db_instance(
+                identifier=self.influxdb_id
+            )
+            elapsed_time = 0
+            while (
+                instance["status"] == "DELETING"
+                and elapsed_time < self.MAXIMUM_WAIT_SECONDS
+            ):
+                time.sleep(self.SLEEP_SECONDS)
+                elapsed_time += self.SLEEP_SECONDS
+                instance = self._timestream_influxdb_client.get_db_instance(
+                    identifier=self.influxdb_id
+                )
+                logger.info(f"Deletion status: {instance['status']}")
+            if (
+                elapsed_time >= self.MAXIMUM_WAIT_SECONDS
+                and instance["status"] == "DELETING"
+            ):
+                logger.error(
+                    f"Failed to delete Timestream for InfluxDB instance {self.influxdb_id}"
+                )
+        # get_db_instance will throw a ResourceNotFoundException when the instance is finished deleting
+        except self._timestream_influxdb_client.exceptions.ResourceNotFoundException:
+            logger.info("Timestream for InfluxDB instance deleted")
+
+    def delete_vpc_and_dependencies(self, vpc_id):
+        """
+        Deletes the Timestream for InfluxDB VPC and all of its associated resources.
+
+        :return: None
+        """
+        try:
+            vpc = self._ec2.Vpc(vpc_id)
+
+            # Delete transit gateway attachments
+            for attachment in self._ec2_client.describe_transit_gateway_attachments()[
+                "TransitGatewayAttachments"
+            ]:
+                if attachment["ResourceId"] == vpc_id:
+                    self._ec2_client.delete_transit_gateway_vpc_attachment(
+                        TransitGatewayAttachmentId=attachment[
+                            "TransitGatewayAttachmentId"
+                        ]
+                    )
+
+            # Delete NAT gateways
+            filters = [{"Name": "vpc-id", "Values": [vpc_id]}]
+            for nat_gateway in self._ec2_client.describe_nat_gateways(Filters=filters)[
+                "NatGateways"
+            ]:
+                self._ec2_client.delete_nat_gateway(
+                    NatGatewayId=nat_gateway["NatGatewayId"]
+                )
+
+            # Detach default DHCP options
+            dhcp_default_options = self._ec2.DhcpOptions("default")
+            if dhcp_default_options:
+                dhcp_default_options.associate_with_vpc(VpcId=vpc_id)
+
+            # Delete gateways
+            for gateway in vpc.internet_gateways.all():
+                vpc.detach_internet_gateway(InternetGatewayId=gateway.id)
+                gateway.delete()
+
+            # Delete any VPC peering connections
+            request_peers = self._ec2_client.describe_vpc_peering_connections(
+                Filters=[{"Name": "requester-vpc-info.vpc-id", "Values": [vpc_id]}]
+            )
+            accept_peers = self._ec2_client.describe_vpc_peering_connections(
+                Filters=[{"Name": "accepter-vpc-info.vpc-id", "Values": [vpc_id]}]
+            )
+            for peer in request_peers["VpcPeeringConnections"]:
+                self._ec2.VpcPeeringConnection(peer["VpcPeeringConnectionId"]).delete()
+            for peer in accept_peers["VpcPeeringConnections"]:
+                self._ec2.VpcPeeringConnection(peer["VpcPeeringConnectionId"]).delete()
+
+            # Delete endpoints
+            endpoints = self._ec2_client.describe_vpc_endpoints(
+                Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]
+            )
+            for endpoint in endpoints["VpcEndpoints"]:
+                self._ec2_client.delete_vpc_endpoints(
+                    VpcEndpointIds=endpoint["VpcEndpointId"]
+                )
+
+            # Delete security groups
+            for security_group in vpc.security_groups.all():
+                if security_group.group_name != "default":
+                    security_group.delete()
+
+            # Delete non-default network ACLs
+            for net_acl in vpc.network_acls.all():
+                if not net_acl.is_default:
+                    net_acl.delete()
+
+            try:
+                # Delete route tables and route table associations
+                filters = [{"Name": "vpc-id", "Values": [vpc_id]}]
+                route_tables = self._ec2_client.describe_route_tables(Filters=filters)[
+                    "RouteTables"
+                ]
+                for route_table in route_tables:
+                    for route in route_table["Routes"]:
+                        if route["Origin"] == "CreateRoute":
+                            self._ec2_client.delete_route(
+                                RouteTableId=route_table["RouteTableId"],
+                                DestinationCidrBlock=route["DestinationCidrBlock"],
+                            )
+                        for association in route_table["Associations"]:
+                            if not association["Main"]:
+                                self._ec2_client.disassociate_route_table(
+                                    AssociationId=association["RouteTableAssociationId"]
+                                )
+                                self._ec2_client.delete_route_table(
+                                    RouteTableId=route_table["RouteTableId"]
+                                )
+                for route_table in route_tables:
+                    if route_table["Associations"] == []:
+                        self._ec2_client.delete_route_table(
+                            RouteTableId=route_table["RouteTableId"]
+                        )
+            except ClientError:
+                # An exception will be raised for a route not having a DestinationCidrBlock of 0.0.0.0/0
+                # this can be ignored
+                pass
+
+            # Delete subnets and network interfaces
+            for subnet in vpc.subnets.all():
+                for interface in subnet.network_interfaces.all():
+                    interface.delete()
+                for instance in subnet.instances.all():
+                    filters = [{"Name": "instance-id", "Values": [instance.id]}]
+                    eips = self._ec2_client.describe_addresses(Filters=filters)[
+                        "Addresses"
+                    ]
+                    for eip in eips:
+                        self._ec2_client.disassociate_address(
+                            AssociationId=eip["AssociationId"]
+                        )
+                        self._ec2_client.release_address(
+                            AllocationId=eip["AllocationId"]
+                        )
+                subnet.delete()
+
+            # Delete instances
+            filters = [
+                {"Name": "instance-state-name", "Values": ["running"]},
+                {"Name": "vpc-id", "Values": [vpc_id]},
+            ]
+            ec2_instances = self._ec2_client.describe_instances(Filters=filters)
+            instance_ids = []
+            for reservation in ec2_instances["Reservations"]:
+                instance_ids += [
+                    instance["InstanceId"] for instance in reservation["Instances"]
+                ]
+            if len(instance_ids) > 0:
+                waiter = self._ec2_client.get_waiter("instance_terminated")
+                self._ec2_client.terminate_instances(InstanceIds=instance_ids)
+                waiter.wait(InstanceIds=instance_ids)
+
+            # Delete VPC
+            self._ec2_client.delete_vpc(VpcId=vpc_id)
+        except Exception as error:
+            logger.error(repr(error))
+            logger.error("Failed to delete VPC and dependencies")
+
+    def delete_non_admin_tokens(self):
+        """
+        Deletes all tokens in the Timestream for InfluxDB instance that does not
+            match the current static operator token.
+
+        :return: None
+        """
+        try:
+            auths = self.influxdb_client.authorizations_api().find_authorizations(
+                org_id=self.influxdb_org_id
+            )
+            for auth in auths:
+                if auth.token != self.static_operator_token:
+                    self.influxdb_client.authorizations_api().delete_authorization(auth)
+        except ApiException as error:
+            logger.error(repr(error))
+
+    def reset_admin_password(self):
+        """
+        Resets the admin password in Timestream for InfluxDB to the password
+            set in init_timestream_for_influxdb.
+
+        :return: None
+        """
+        self.influxdb_client.users_api().update_password(
+            user=self.influxdb_admin_id, password=self.influxdb_admin_password
+        )
+
+    def reset_non_existent_user(self):
+        """
+        Ensures the non-existent user, needed for testing, remains non-existent by
+            deleting this user if it exists in the Timestream for InfluxDB instance.
+
+        :return: None
+        """
+        try:
+            users = (
+                self.influxdb_client.users_api()
+                .find_users(name=self.NON_EXISTENT_USERNAME)
+                .users
+            )
+            if users is not None:
+                for user in users:
+                    self.influxdb_client.users_api().delete_user(user)
+        except ApiException:
+            pass

--- a/SecretsManagerInfluxDBSingleUserRotation/integration/integration_test.py
+++ b/SecretsManagerInfluxDBSingleUserRotation/integration/integration_test.py
@@ -1,0 +1,358 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import argparse
+import os
+import sys
+import unittest
+
+from aws_integration_test_client import AWSIntegrationTestClient
+from influxdb_integration_test_client import InfluxDBIntegrationTestClient
+from integration_test_utils import logger
+
+aws_region_name = ""
+
+# Whether to delete all AWS resources after testing
+cleanup = False
+
+
+class BaseTestCases:
+    class BaseTestCase(unittest.TestCase):
+        admin_secret_dict = {}
+        aws_it_client: AWSIntegrationTestClient
+        influxdb_it_client: InfluxDBIntegrationTestClient
+
+        @classmethod
+        def setUpClass(cls):
+            cls.aws_it_client = AWSIntegrationTestClient(region_name=aws_region_name)
+            cls.influxdb_it_client = InfluxDBIntegrationTestClient(
+                region_name=aws_region_name
+            )
+            try:
+                cls.influxdb_it_client.init_timestream_for_influxdb()
+                cls.aws_it_client.init_secrets(
+                    engine=cls.influxdb_it_client.TIMESTREAM_INFLUXDB_ENGINE,
+                    username=cls.influxdb_it_client.INFLUXDB_ADMIN_USERNAME,
+                    password=cls.influxdb_it_client.influxdb_admin_password,
+                    token=cls.influxdb_it_client.static_operator_token,
+                    influxdb_id=cls.influxdb_it_client.influxdb_id,
+                    org_name=cls.influxdb_it_client.INFLUXDB_ORG_NAME,
+                )
+                cls.aws_it_client.init_lambda_function(
+                    influxdb_arn=cls.influxdb_it_client.influxdb_arn
+                )
+            except Exception as error:
+                logger.error(repr(error))
+                logger.error("Test initialization failed. Exiting . . .")
+                exit(1)
+
+        def setUp(self):
+            """
+            Overrides unittest.TestCase.setUp, called before each test runs.
+            """
+            assert self.aws_it_client is not None
+            assert self.influxdb_it_client is not None
+            # Create a new InfluxDB token and initialize self.admin_secret_dict to default values
+            self.influxdb_it_client.create_current_auth()
+            self.set_admin_secret_dict(
+                token=self.influxdb_it_client.current_auth.token,
+            )
+            # Stop a rotation if it was left in progress
+            self.aws_it_client.cancel_rotate_admin_secret()
+
+        def set_admin_secret_dict(
+            self,
+            db_identifier=None,
+            org_name=None,
+            token=None,
+            username=None,
+            password=None,
+        ):
+            """
+            Sets internal secret dict.
+            """
+            # Mandatory fields
+            secret_dict = {
+                "engine": self.influxdb_it_client.TIMESTREAM_INFLUXDB_ENGINE,
+                "dbIdentifier": db_identifier
+                if db_identifier is not None
+                else self.influxdb_it_client.influxdb_id,
+                "org": org_name
+                if org_name is not None
+                else self.influxdb_it_client.INFLUXDB_ORG_NAME,
+            }
+            if token is not None:
+                secret_dict["token"] = token
+            if username is not None:
+                secret_dict["username"] = username
+            if password is not None:
+                secret_dict["password"] = password
+            self.admin_secret_dict = secret_dict
+
+        def tearDown(self):
+            """
+            Overrides unittest.TestCase.tearDown, called after each test runs.
+            """
+            if self.aws_it_client is not None:
+                # Stop a rotation if it was left in progress
+                self.aws_it_client.cancel_rotate_admin_secret()
+                # Reset admin token value to an authenticated token
+                admin_secret_dict = self.aws_it_client.get_admin_secret_dict()
+                admin_secret_dict["token"] = (
+                    self.influxdb_it_client.static_operator_token
+                )
+                self.aws_it_client.set_version_id()
+                self.aws_it_client.post_admin_secret(secret_dict=admin_secret_dict)
+                self.aws_it_client.set_create_auth(False)
+            if self.influxdb_it_client is not None:
+                self.influxdb_it_client.reset_admin_password()
+                # The non-existent user must remain non-existent
+                self.influxdb_it_client.reset_non_existent_user()
+                self.influxdb_it_client.delete_non_admin_tokens()
+
+        @classmethod
+        def tearDownClass(cls):
+            if cls.influxdb_it_client.influxdb_client is not None:
+                cls.influxdb_it_client.influxdb_client.close()
+            if cleanup:
+                cls.aws_it_client.teardown()
+                cls.influxdb_it_client.teardown()
+
+
+class SecretsTestCase(BaseTestCases.BaseTestCase):
+    def test_operator_token_rotation_no_token(self):
+        """
+        Failure rotation for operator token without token provided.
+        """
+        self.set_admin_secret_dict()
+        self.aws_it_client.post_admin_secret(secret_dict=self.admin_secret_dict)
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), False)
+        new_secret_dict = self.aws_it_client.get_admin_secret_dict()
+        self.assertNotIn("token", new_secret_dict)
+
+    def test_random_operator_token_rotation(self):
+        """
+        Failure rotation for random operator token.
+        """
+        self.set_admin_secret_dict(token="random-token")
+        self.aws_it_client.post_admin_secret(secret_dict=self.admin_secret_dict)
+        old_token = self.admin_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), False)
+        new_token = self.aws_it_client.get_admin_secret_dict()["token"]
+        self.assertEqual(old_token, new_token)
+
+    def test_username_and_password_rotation_incorrect_password(self):
+        """
+        Wrong password set for user fails.
+        """
+        self.set_admin_secret_dict(
+            username=self.influxdb_it_client.INFLUXDB_ADMIN_USERNAME,
+            password="this-is-an-incorrect-password",
+        )
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        old_password = self.admin_secret_dict["password"]
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), False)
+        new_password = self.aws_it_client.get_admin_secret_dict()["password"]
+        self.assertEqual(old_password, new_password)
+
+    def test_username_and_password_rotation_no_password(self):
+        """
+        Failure rotation for admin credentials without password provided.
+        """
+        self.set_admin_secret_dict(
+            username=self.influxdb_it_client.INFLUXDB_ADMIN_USERNAME
+        )
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), False)
+        new_secret_dict = self.aws_it_client.get_admin_secret_dict()
+        self.assertNotIn("password", new_secret_dict)
+
+    def test_username_and_password_rotation_non_existent_user(self):
+        """
+        Non-existent-user set fails.
+        """
+        self.set_admin_secret_dict(
+            username=self.influxdb_it_client.NON_EXISTENT_USERNAME, password="rosebud"
+        )
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        old_password = self.admin_secret_dict["password"]
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), False)
+        new_password = self.aws_it_client.get_admin_secret_dict()["password"]
+        self.assertEqual(old_password, new_password)
+
+    def test_operator_token_rotation_missing_mandatory_fields(self):
+        """
+        Failures for token rotation without mandatory secret fields.
+
+        Mandatory secret fields are "engine," "org," "dbIdentifier," and "token."
+        """
+        self.admin_secret_dict.pop("engine", None)
+        self.admin_secret_dict.pop("dbIdentifier", None)
+        self.admin_secret_dict.pop("org", None)
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        old_token = self.admin_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), False)
+        new_token = self.aws_it_client.get_admin_secret_dict()["token"]
+        self.assertEqual(old_token, new_token)
+
+        self.admin_secret_dict["engine"] = (
+            self.influxdb_it_client.TIMESTREAM_INFLUXDB_ENGINE
+        )
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), False)
+        new_token = self.aws_it_client.get_admin_secret_dict()["token"]
+        self.assertEqual(old_token, new_token)
+
+        self.admin_secret_dict["org"] = self.influxdb_it_client.INFLUXDB_ORG_NAME
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), False)
+        new_token = self.aws_it_client.get_admin_secret_dict()["token"]
+        self.assertEqual(old_token, new_token)
+
+        # Now, expect success
+        self.admin_secret_dict["dbIdentifier"] = self.influxdb_it_client.influxdb_id
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), True)
+        new_token = self.aws_it_client.get_admin_secret_dict()["token"]
+        self.assertNotEqual(old_token, new_token)
+
+    def test_username_and_password_rotation_missing_mandatory_fields(self):
+        """
+        Failures for credential rotation without mandatory secret fields.
+
+        Mandatory secret fields are "engine," "dbIdentifier," "username," and "password."
+        """
+        self.set_admin_secret_dict(
+            password=self.influxdb_it_client.influxdb_admin_password
+        )
+        self.admin_secret_dict.pop("engine", None)
+        self.admin_secret_dict.pop("dbIdentifier", None)
+        self.admin_secret_dict.pop("username", None)
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        old_password = self.admin_secret_dict["password"]
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), False)
+        new_password = self.aws_it_client.get_admin_secret_dict()["password"]
+        self.assertEqual(old_password, new_password)
+
+        self.admin_secret_dict["engine"] = (
+            self.influxdb_it_client.TIMESTREAM_INFLUXDB_ENGINE
+        )
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), False)
+        new_password = self.aws_it_client.get_admin_secret_dict()["password"]
+        self.assertEqual(old_password, new_password)
+
+        self.admin_secret_dict["dbIdentifier"] = self.influxdb_it_client.influxdb_id
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), False)
+        new_password = self.aws_it_client.get_admin_secret_dict()["password"]
+        self.assertEqual(old_password, new_password)
+
+        self.admin_secret_dict["username"] = (
+            self.influxdb_it_client.INFLUXDB_ADMIN_USERNAME
+        )
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), True)
+        new_password = self.aws_it_client.get_admin_secret_dict()["password"]
+        self.assertNotEqual(old_password, new_password)
+
+    def test_operator_token_rotation(self):
+        """
+        Successful rotation for operator token with token provided.
+        """
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        old_token = self.admin_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), True)
+        new_token = self.aws_it_client.get_admin_secret_dict()["token"]
+        self.assertNotEqual(old_token, new_token)
+
+    def test_retrigger_operator_token_rotation(self):
+        """
+        Successful re-rotation for operator token
+        """
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        old_token = self.admin_secret_dict["token"]
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), True)
+        new_token = self.aws_it_client.get_admin_secret_dict()["token"]
+        self.assertNotEqual(old_token, new_token)
+        old_token = new_token
+
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), True)
+        new_token = self.aws_it_client.get_admin_secret_dict()["token"]
+        self.assertNotEqual(old_token, new_token)
+
+    def test_username_and_password_rotation(self):
+        """
+        Successful rotation for admin credentials with credentials provided.
+        """
+        self.set_admin_secret_dict(
+            username=self.influxdb_it_client.INFLUXDB_ADMIN_USERNAME,
+            password=self.influxdb_it_client.influxdb_admin_password,
+        )
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        old_password = self.admin_secret_dict["password"]
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), True)
+        new_password = self.aws_it_client.get_admin_secret_dict()["password"]
+        self.assertNotEqual(old_password, new_password)
+
+    def test_retrigger_username_and_password_rotation(self):
+        """
+        Successful re-rotation for admin credentials with credentials provided.
+        """
+        self.set_admin_secret_dict(
+            username=self.influxdb_it_client.INFLUXDB_ADMIN_USERNAME,
+            password=self.influxdb_it_client.influxdb_admin_password,
+        )
+        self.aws_it_client.post_admin_secret(self.admin_secret_dict)
+        old_password = self.admin_secret_dict["password"]
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), True)
+        new_password = self.aws_it_client.get_admin_secret_dict()["password"]
+        self.assertNotEqual(old_password, new_password)
+        old_password = new_password
+
+        self.assertEqual(self.aws_it_client.rotate_admin_secret(), True)
+        new_password = self.aws_it_client.get_admin_secret_dict()["password"]
+        self.assertNotEqual(old_password, new_password)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="Single-user rotation Lambda integration tests"
+    )
+    parser.add_argument(
+        "--region",
+        help="The name of the AWS region to use for integration testing. "
+        "If not provided, will default to the AWS_DEFAULT_REGION environment variable.",
+        required=False,
+    )
+    parser.add_argument(
+        "--cleanup",
+        help="Whether to teardown all testing resources, including the "
+        "Timestream for InfluxDB instance and secrets.",
+        required=False,
+        action="store_true",
+    )
+    args, unknown = parser.parse_known_args()
+    if args.region is not None:
+        aws_region_name = args.region
+        os.environ["AWS_DEFAULT_REGION"] = aws_region_name
+    else:
+        try:
+            aws_region_name = os.environ["AWS_DEFAULT_REGION"]
+        except KeyError:
+            logger.error("AWS_DEFAULT_REGION environment variable not set. Exiting.")
+            exit(1)
+
+    cleanup = args.cleanup
+
+    # unittest.main() also parses sys.argv and won't recognize --cleanup or --region
+    filtered_argv = []
+    for i in range(len(sys.argv)):
+        if (
+            sys.argv[i] != "--cleanup"
+            and sys.argv[i] != "--region"
+            and (i == 0 or sys.argv[i - 1] != "--region")
+        ):
+            filtered_argv.append(sys.argv[i])
+    sys.argv = filtered_argv
+    unittest.main(exit=False)

--- a/SecretsManagerInfluxDBSingleUserRotation/integration/integration_test_utils.py
+++ b/SecretsManagerInfluxDBSingleUserRotation/integration/integration_test_utils.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import string
+import secrets
+import logging
+
+logger = logging.getLogger("integration_test.py")
+logger.setLevel(logging.INFO)
+log_handler = logging.StreamHandler()
+log_formatter = logging.Formatter("%(levelname)s: %(message)s")
+log_handler.setFormatter(log_formatter)
+logger.addHandler(log_handler)
+
+
+def random_string(n):
+    return "".join(
+        secrets.choice(string.ascii_letters + string.digits) for _ in range(n)
+    )

--- a/SecretsManagerInfluxDBSingleUserRotation/lambda_function.py
+++ b/SecretsManagerInfluxDBSingleUserRotation/lambda_function.py
@@ -1,0 +1,620 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import boto3
+import json
+import logging
+import os
+import influxdb_client
+from contextlib import contextmanager
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+TIMESTREAM_INFLUXDB_SERVICE = "timestream-influxdb"
+
+# Mandatory user and token secret fields
+INFLUXDB_ENGINE = "engine"
+INFLUXDB_INSTANCE_IDENTIFIER = "dbIdentifier"
+
+# Mandatory user secret fields
+INFLUXDB_USERNAME = "username"
+
+# Optional user and token secret fields
+INFLUXDB_ORG = "org"
+
+# Optional user secret fields
+INFLUXDB_PASSWORD = "password"
+
+# Optional token secret fields
+INFLUXDB_TOKEN = "token"
+
+# Stages
+CURRENT_STAGE = "AWSCURRENT"
+PENDING_STAGE = "AWSPENDING"
+
+# Steps
+CREATE_STEP = "createSecret"
+SET_STEP = "setSecret"
+TEST_STEP = "testSecret"
+FINISH_STEP = "finishSecret"
+
+# get_db_info response fields
+INFLUXDB_ENDPOINT = "endpoint"
+
+# Environment variable keys
+SECRETS_MANAGER_ENDPOINT = "SECRETS_MANAGER_ENDPOINT"
+
+
+def lambda_handler(event, context):
+    """Secrets Manager InfluxDB Token Rotation Handler
+
+    This handler uses a single users token to rotate their InfluxDB authentication token. This rotation scheme
+    authenticates the current user in the InfluxDB instance and creates a new token for the user with the same
+    permissions. The new token is then authenticated and verified to have the same properties as the previous token.
+    The old token is then deleted, and the rotation is complete. InfluxDB client does not support setting a custom
+    value for a token, so the createSecret and setSecret events both take place during the createSecret step.
+
+    Args:
+        event (dict): Lambda dictionary of event parameters. These keys must include the following:
+            - SecretId: The secret ARN or identifier
+            - ClientRequestToken: The ClientRequestToken of the secret version
+            - Step: The rotation step (one of createSecret, setSecret, testSecret, or finishSecret)
+
+        context (LambdaContext): The Lambda runtime information
+
+    Raises:
+        ResourceNotFoundException: If the secret with the specified arn and stage does not exist
+
+        ValueError: If the secret is not properly configured for rotation
+
+    """
+    arn = event["SecretId"]
+    version_id = event["ClientRequestToken"]
+    step = event["Step"]
+
+    if arn == "" or arn is None:
+        raise ValueError("arn is null or empty.")
+    if version_id == "" or version_id is None:
+        raise ValueError("version_id is null or empty.")
+    if step == "" or step is None:
+        raise ValueError("step is null or empty.")
+
+    boto_session = boto3.Session()
+
+    if SECRETS_MANAGER_ENDPOINT not in os.environ:
+        raise KeyError(
+            "SECRETS_MANAGER_ENDPOINT environment variable not set in the environment variables."
+        )
+
+    secret_manager_endpoint = os.environ[SECRETS_MANAGER_ENDPOINT]
+    if secret_manager_endpoint == "" or secret_manager_endpoint is None:
+        raise ValueError(
+            "Secret manager endpoint is null or empty, set the environment variable in the lambda configuration."
+        )
+    secrets_client = boto_session.client(
+        "secretsmanager", endpoint_url=secret_manager_endpoint
+    )
+
+    # Make sure the version is staged correctly
+    metadata = secrets_client.describe_secret(SecretId=arn)
+    if not metadata["RotationEnabled"]:
+        logger.error("Secret %s is not enabled for rotation" % arn)
+        raise ValueError("Secret %s is not enabled for rotation" % arn)
+    versions = metadata["VersionIdsToStages"]
+    if version_id not in versions:
+        logger.error(
+            "Secret version %s has no stage for rotation of secret %s."
+            % (version_id, arn)
+        )
+        raise ValueError(
+            "Secret version %s has no stage for rotation of secret %s."
+            % (version_id, arn)
+        )
+    if CURRENT_STAGE in versions[version_id]:
+        logger.info(
+            "Secret version %s already set as AWSCURRENT for secret %s."
+            % (version_id, arn)
+        )
+        return
+    elif PENDING_STAGE not in versions[version_id]:
+        logger.error(
+            "Secret version %s not set as AWSPENDING for rotation of secret %s."
+            % (version_id, arn)
+        )
+        raise ValueError(
+            "Secret version %s not set as AWSPENDING for rotation of secret %s."
+            % (version_id, arn)
+        )
+
+    if step == "createSecret":
+        create_secret(secrets_client, boto_session, arn, version_id)
+
+    elif step == "setSecret":
+        logger.info(
+            "set_secret has no function as we use the value from the already created token in the create_secret stage"
+        )
+
+    elif step == "testSecret":
+        test_secret(secrets_client, boto_session, arn, version_id)
+
+    elif step == "finishSecret":
+        finish_secret(secrets_client, boto_session, arn, version_id)
+
+    else:
+        raise ValueError("Invalid step parameter %s" % step)
+
+
+@contextmanager
+def get_connection(endpoint_url, secret_dict, arn, step):
+    """Get connection to InfluxDB
+
+    This helper function returns a connection to the provided InfluxDB instance.
+
+    Args:
+        endpoint_url (string): Url for the InfluxDB instance
+        secret_dict (dictionary): Dictionary with either username/password or token to authenticate connection
+        arn (string): Arn for secret to log in event of failure to make connection
+        step (string): Step in which the lambda function is making the connection
+
+    Raises:
+        ValueError: If the connection or health check fails
+
+    """
+    conn = None
+    try:
+        conn = (
+            influxdb_client.InfluxDBClient(
+                url="https://" + endpoint_url + ":8086",
+                token=secret_dict[INFLUXDB_TOKEN],
+                debug=False,
+                verify_ssl=True,
+            )
+            if INFLUXDB_TOKEN in secret_dict
+            else influxdb_client.InfluxDBClient(
+                url="https://" + endpoint_url + ":8086",
+                username=secret_dict[INFLUXDB_USERNAME],
+                password=secret_dict[INFLUXDB_PASSWORD],
+                debug=False,
+                verify_ssl=True,
+            )
+        )
+
+        # Verify InfluxDB connection
+        health = conn.ping()
+        if not health:
+            logger.error("%s: Connection failure" % step)
+
+        yield conn
+    except Exception as err:
+        raise ValueError(
+            "%s: Failed to set new authorization with secret ARN %s %s"
+            % (step, arn, err)
+        ) from err
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def create_secret(secrets_client, boto_session, arn, version_id):
+    """Create the secret
+
+    This method first checks for the existence of a secret for the passed in token. If one does not exist,
+    it will generate a new token in the InfluxDB instance, and put the token value in the AWSPENDING secret value.
+    This function completes both the createSecret and setSecret steps.
+
+    Args:
+        secrets_client (client): The secrets manager service client
+        boto_session (session): Session to retrieve timestream-influxdb client
+        arn (string): The secret ARN or other identifier
+        version_id (string): The ClientRequestToken associated with the secret version
+
+    Raises:
+        ResourceNotFoundException: If the secret with the specified arn and stage does not exist
+        ValueError: If the secrets manager token fails to create a new token
+
+    """
+
+    # Make sure the current secret exists
+    current_secret_dict = get_secret_dict(secrets_client, arn, CURRENT_STAGE)
+
+    # Now try to get the secret token, if that fails, put a new secret
+    try:
+        get_secret_dict(secrets_client, arn, PENDING_STAGE, version_id)
+        logger.info("create_secret: Successfully retrieved secret for %s." % arn)
+    except secrets_client.exceptions.ResourceNotFoundException:
+        with get_connection(
+            get_db_info(
+                current_secret_dict[INFLUXDB_INSTANCE_IDENTIFIER], boto_session
+            ),
+            current_secret_dict,
+            arn,
+            CREATE_STEP,
+        ) as conn:
+            if INFLUXDB_TOKEN in current_secret_dict:
+                token_perms = validate_current_token(conn, current_secret_dict)
+                create_token(conn, current_secret_dict, token_perms)
+            else:
+                update_user_creds(
+                    secrets_client, boto_session, arn, conn, current_secret_dict
+                )
+
+            secrets_client.put_secret_value(
+                SecretId=arn,
+                ClientRequestToken=version_id,
+                SecretString=json.dumps(current_secret_dict),
+                VersionStages=[PENDING_STAGE],
+            )
+
+    logger.info(
+        "create_secret: Successfully created new authorization for ARN %s and version %s."
+        % (arn, version_id)
+    )
+
+
+def update_user_creds(secrets_client, boto_session, arn, conn, current_secret_dict):
+    """Update credentials for user
+
+    Set the new user credentials in the InfluxDB instance. A valid password must be supplied in the secret, and then a new password will be
+    generated for that user.
+
+    Args:
+        secrets_client (client): The secrets manager service client
+        boto_session (session): Session to retrieve timestream-influxdb client
+        arn (string): The secret ARN or other identifier
+        conn (InfluxDBClient): Connection to InfluxDB instance
+        current_secret_dict (dictionary): Dictionary with the user and password being set
+
+    """
+
+    users = conn.users_api().find_users()
+    # Search through users for one that matches the current user
+    user = next(
+        (
+            user
+            for user in users.users
+            if user.name == current_secret_dict[INFLUXDB_USERNAME]
+        ),
+        None,
+    )
+
+    if INFLUXDB_PASSWORD not in current_secret_dict:
+        raise ValueError(
+            "User %s password has not been set yet, set the password before performing a rotation."
+            % current_secret_dict[INFLUXDB_USERNAME]
+        )
+
+    if user is None:
+        raise ValueError(
+            "User %s has not been created, create the user before performing a rotation"
+            % current_secret_dict[INFLUXDB_USERNAME]
+        )
+
+    with get_connection(
+        get_db_info(current_secret_dict[INFLUXDB_INSTANCE_IDENTIFIER], boto_session),
+        current_secret_dict,
+        arn,
+        CREATE_STEP,
+    ) as test_user_client:
+        # Ensure user defined in secret can authenticate
+        test_user_client.users_api().me()
+
+    new_password = secrets_client.get_random_password()["RandomPassword"]
+    conn.users_api().update_password(user=user.id, password=new_password)
+    current_secret_dict[INFLUXDB_PASSWORD] = new_password
+
+
+def validate_current_token(conn, current_secret_dict):
+    """
+
+    Validates that the permission set for the token type line up with those defined by the current token.
+
+    Args:
+        conn (InfluxDBClient): The connection to the InfluxDB instance
+        current_secret_dict (dictionary): Secret dictionary with token type and permissions
+
+    Raises:
+        ValueError: If token type and permissions are not set appropriately
+
+    Returns
+        final_token_perms (list): All permissions that should be set
+    """
+
+    # Ensure no operator tokens can be created without an already existing token
+    if INFLUXDB_TOKEN not in current_secret_dict:
+        raise ValueError(
+            "Operator tokens cannot be created without an already existing operator token"
+        )
+
+    # Ensure the already created token has the same permissions as defined in the secret
+    authorizations = conn.authorizations_api().find_authorizations()
+    current_auth = next(
+        (
+            auth
+            for auth in authorizations
+            if auth.token == current_secret_dict[INFLUXDB_TOKEN]
+        ),
+        None,
+    )
+    if current_auth is None:
+        raise ValueError("Current authorization token not found in DB instance")
+
+    logger.info(
+        "Existing token found in DB instance, token will be rotated with existing permissions"
+    )
+    return current_auth.permissions
+
+
+def create_token(conn, current_secret_dict, token_perms):
+    """
+
+    Create new authorization token in InfluxDB instance. The type and permissions are set from the values
+    defined in the secret dictionary. If these values have been altered then the new auth token will not be created.
+
+    Args:
+        conn (InfluxDBClient): The connection to the InfluxDB instance
+        current_secret_dict (dictionary): Secret dictionary with token type and permissions
+        token_perms (list): Set of permissions to apply to the token being created
+
+    Raises:
+        ValueError: If no permissions are set for token
+
+    """
+
+    org = next(
+        (
+            org
+            for org in conn.organizations_api().find_organizations()
+            if org.name == current_secret_dict[INFLUXDB_ORG]
+        ),
+        None,
+    )
+    if org is None:
+        raise ValueError("Org does not exist to associate token value with")
+
+    # Influxdb doesn't support setting token values for already created tokens
+    # We must therefore create the token in InfluxDB at this stage
+    new_authorization = conn.authorizations_api().create_authorization(
+        org_id=org.id, permissions=token_perms
+    )
+    current_secret_dict[INFLUXDB_TOKEN] = new_authorization.token
+
+
+def test_secret(secrets_client, boto_session, arn, version_id):
+    """Test the token against the InfluxDB instance
+
+    This method authenticates the tokens in the AWSCURRENT and AWSPENDING stages against the InfluxDB instance. Once
+    both tokens have been authenticated, the users the tokens belong to is verified to be the same,
+    and the authentication tokens are verified to have the same permission values.
+
+    Args:
+        secrets_client (client): The secrets manager service client
+        boto_session (session): Session to retrieve timestream-influxdb client
+        arn (string): The secret ARN or other identifier
+        version_id (string): The ClientRequestToken associated with the secret version
+
+    Raises: ValueError: If the secrets manager or pending user tokens fail to authenticate, or the current and
+    pending token permissions or users are not identical.
+
+    """
+
+    current_secret_dict = get_secret_dict(secrets_client, arn, CURRENT_STAGE)
+    pending_secret_dict = get_secret_dict(
+        secrets_client, arn, PENDING_STAGE, version_id
+    )
+
+    with get_connection(
+        get_db_info(current_secret_dict[INFLUXDB_INSTANCE_IDENTIFIER], boto_session),
+        pending_secret_dict,
+        arn,
+        CREATE_STEP,
+    ) as client:
+        if (
+            INFLUXDB_TOKEN in pending_secret_dict
+            and INFLUXDB_TOKEN in current_secret_dict
+        ):
+            authorizations = client.authorizations_api().find_authorizations()
+            current_auth = next(
+                (
+                    auth
+                    for auth in authorizations
+                    if auth.token == current_secret_dict[INFLUXDB_TOKEN]
+                ),
+                None,
+            )
+            pending_auth = next(
+                (
+                    auth
+                    for auth in authorizations
+                    if auth.token == pending_secret_dict[INFLUXDB_TOKEN]
+                ),
+                None,
+            )
+
+            if current_auth is None or pending_auth is None:
+                raise ValueError(
+                    "Current or pending token does not exist for secret ARN %s" % arn
+                )
+
+            # Validate current and pending tokens have the same permissions
+            if current_auth.permissions != pending_auth.permissions:
+                raise ValueError(
+                    "Current and pending tokens do not have the same permissions for secret ARN %s"
+                    % arn
+                )
+
+            # Validate current and pending tokens have the same user
+            if current_auth.user != pending_auth.user:
+                raise ValueError(
+                    "Current and pending tokens failed user equality test for secret ARN %s"
+                    % arn
+                )
+
+    logger.info("test_secret: Successfully tested authentication rotation")
+
+
+def finish_secret(secrets_client, boto_session, arn, version_id):
+    """Finish the secret
+
+    This method finalizes the rotation process by marking the secret version passed in as the AWSCURRENT secret and
+    deleting the previous user authentication token in the InfluxDB instance.
+
+    Args:
+        secrets_client (client): The secrets manager service client
+        boto_session (session): Session to retrieve timestream-influxdb client
+        arn (string): The secret ARN or other identifier
+        version_id (string): The ClientRequestToken associated with the secret version
+
+    Raises:
+        ValueError: If the secrets manager fails to delete the previous user token in the InfluxDB instance.
+
+    """
+    current_secret_dict = get_secret_dict(secrets_client, arn, CURRENT_STAGE)
+    pending_secret_dict = get_secret_dict(
+        secrets_client, arn, PENDING_STAGE, version_id
+    )
+
+    # First describe the secret to get the current version
+    metadata = secrets_client.describe_secret(SecretId=arn)
+    current_version = None
+    for version in metadata["VersionIdsToStages"]:
+        if CURRENT_STAGE in metadata["VersionIdsToStages"][version]:
+            if version == version_id:
+                # The correct version is already marked as current, return
+                logger.info(
+                    "finish_secret: Version %s already marked as AWSCURRENT for %s"
+                    % (version, arn)
+                )
+                return
+            current_version = version
+            break
+
+    # Finalize by staging the secret version current
+    secrets_client.update_secret_version_stage(
+        SecretId=arn,
+        VersionStage=CURRENT_STAGE,
+        MoveToVersionId=version_id,
+        RemoveFromVersionId=current_version,
+    )
+
+    # Delete previous authorization for user if using token authentication
+    if INFLUXDB_TOKEN in pending_secret_dict and INFLUXDB_TOKEN in current_secret_dict:
+        with get_connection(
+            get_db_info(
+                current_secret_dict[INFLUXDB_INSTANCE_IDENTIFIER], boto_session
+            ),
+            pending_secret_dict,
+            arn,
+            CREATE_STEP,
+        ) as operator_client:
+            authorizations = operator_client.authorizations_api().find_authorizations()
+            current_auth = next(
+                (
+                    auth
+                    for auth in authorizations
+                    if auth.token == current_secret_dict[INFLUXDB_TOKEN]
+                )
+            )
+            operator_client.authorizations_api().delete_authorization(current_auth)
+
+    logger.info(
+        "finish_secret: Successfully set AWSCURRENT stage to version %s for secret %s."
+        % (version_id, arn)
+    )
+
+
+def get_secret_dict(secrets_client, arn, stage, version_id=None):
+    """Gets the secret dictionary corresponding for the secret arn, stage, and token
+
+    This helper function gets credentials for the arn and stage passed in and returns the dictionary by parsing the
+    JSON string
+
+    Args: secrets_client (client): The secrets manager service client arn (string): The secret ARN or other
+    identifier stage (string): The stage identifying the secret version version_id (string): The ClientRequestToken
+    associated with the secret version, or None if no validation is desired
+
+    Returns:
+        SecretDictionary: Secret dictionary
+
+    Raises:
+        ResourceNotFoundException: If the secret with the specified arn and stage does not exist
+        ValueError: If the secret is not valid JSON
+        KeyError: If required keys missing in secret or engine is not 'timestream-influxdb'
+
+    """
+
+    # Only do VersionId validation against the stage if a token is passed in
+    if version_id:
+        secret = secrets_client.get_secret_value(
+            SecretId=arn, VersionId=version_id, VersionStage=stage
+        )
+    else:
+        secret = secrets_client.get_secret_value(SecretId=arn, VersionStage=stage)
+    plaintext = secret["SecretString"]
+    try:
+        secret_dict = json.loads(plaintext)
+    except Exception:
+        # wrapping json parser exceptions to avoid possible token disclosure
+        logger.error("Invalid secret value json for secret %s." % arn)
+        raise ValueError("Invalid secret value json for secret %s." % arn)
+
+    if (
+        INFLUXDB_TOKEN not in secret_dict
+        and INFLUXDB_USERNAME not in secret_dict
+        and INFLUXDB_PASSWORD not in secret_dict
+    ):
+        raise KeyError(
+            "No credentials were provided to authenticate with the DB instance"
+        )
+
+    # Run semantic validations for secrets
+    if INFLUXDB_TOKEN in secret_dict:
+        required_fields = [
+            INFLUXDB_ENGINE,
+            INFLUXDB_ORG,
+            INFLUXDB_INSTANCE_IDENTIFIER,
+            INFLUXDB_TOKEN,
+        ]
+    else:
+        required_fields = [
+            INFLUXDB_ENGINE,
+            INFLUXDB_INSTANCE_IDENTIFIER,
+            INFLUXDB_USERNAME,
+            INFLUXDB_PASSWORD,
+        ]
+
+    for field in required_fields:
+        if field not in secret_dict:
+            raise KeyError("%s key is missing from secret JSON" % field)
+
+    if secret_dict["engine"] != TIMESTREAM_INFLUXDB_SERVICE:
+        raise KeyError(
+            "Database engine must be set to 'timestream-influxdb' in order to use this rotation lambda"
+        )
+
+    return secret_dict
+
+
+def get_db_info(db_instance_identifier, boto_session):
+    """Get InfluxDB information
+
+    This helper function returns the url for the InfluxDB instance that matches the identifier
+    that is provided in the user secret.
+
+    Args:
+        db_instance_identifier (string): The InfluxDB instance identifier
+        boto_session (session): Session to retrieve timestream-influxdb client
+
+    Raises:
+        ValueError: Failed to retrieve DB information
+        KeyError: DB info returned does not contain expected key
+
+    """
+
+    influx_client = boto_session.client(TIMESTREAM_INFLUXDB_SERVICE)
+    describe_response = influx_client.get_db_instance(identifier=db_instance_identifier)
+
+    if describe_response is None or describe_response[INFLUXDB_ENDPOINT] is None:
+        raise KeyError("Invalid endpoint info for influxdb instance")
+
+    return describe_response[INFLUXDB_ENDPOINT]

--- a/SecretsManagerInfluxDBSingleUserRotation/lambda_function.py
+++ b/SecretsManagerInfluxDBSingleUserRotation/lambda_function.py
@@ -529,9 +529,11 @@ def get_secret_dict(secrets_client, arn, stage, version_id=None):
     This helper function gets credentials for the arn and stage passed in and returns the dictionary by parsing the
     JSON string
 
-    Args: secrets_client (client): The secrets manager service client arn (string): The secret ARN or other
-    identifier stage (string): The stage identifying the secret version version_id (string): The ClientRequestToken
-    associated with the secret version, or None if no validation is desired
+    Args:
+        secrets_client (client): The secrets manager service client
+        arn (string): The secret ARN or other identifier
+        stage (string): The stage identifying the secret version
+        version_id (string): The ClientRequestToken associated with the secret version, or None if no validation is desired
 
     Returns:
         SecretDictionary: Secret dictionary

--- a/SecretsManagerInfluxDBSingleUserRotation/requirements.txt
+++ b/SecretsManagerInfluxDBSingleUserRotation/requirements.txt
@@ -1,0 +1,2 @@
+influxdb-client[ciso]
+boto3


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The InfluxDB Single and Multi-user Secret Rotation Lambdas enables the automatic rotation for authorizations with `Timestream for InfluxDB`. The Multi-user rotation lambda uses an admin authenticated session to rotate another set of user or token credentials. The Single-user rotation lambda rotates their own authenticated session, and require the appropriate permissions to perform the rotation. The Multi-user rotation lambda can be used to rotate any credentials with any permissions.

Validations:
- [x] - Multi-user secret rotation integration tests
- [x] - Single-user secret rotation integration tests
- [x] - Ruff formatting
- [x] - Ruff linting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
